### PR TITLE
fix: power button does nothing while a controller is connected

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p output/scripts output/illusion/MapperManager
           cp target/armv7-unknown-linux-musleabihf/release/kindle-button-mapper output/
           cp kindle-button-mapper.init output/
-          cp scripts/koreader.sh scripts/key.sh scripts/start-inhib.sh scripts/stop-inhib.sh output/scripts/
+          cp scripts/koreader.sh scripts/key.sh output/scripts/
           cp illusion/MapperManager.sh illusion/install-waf-app.sh output/illusion/
           cp illusion/MapperManager/config.xml illusion/MapperManager/index.html \
              illusion/MapperManager/style.css illusion/MapperManager/script.js \
@@ -78,8 +78,6 @@ jobs:
             kindle-button-mapper.init \
             scripts/koreader.sh \
             scripts/key.sh \
-            scripts/start-inhib.sh \
-            scripts/stop-inhib.sh \
             illusion/MapperManager.sh \
             illusion/install-waf-app.sh \
             illusion/MapperManager/config.xml \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "kindle-button-mapper"
-version = "0.3.1"
+version = "1.0.0"
 dependencies = [
  "configparser",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kindle-button-mapper"
-version = "0.3.1"
+version = "1.0.0"
 edition = "2021"
 description = "Maps /dev/input events to script execution for Kindle e-readers"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ debounce_ms = 200
 long_press_ms = 500
 repeat_ms = 100
 log_buttons = true
+keep_awake = true
 on_connect = /path/to/script.sh
 on_disconnect = /path/to/script.sh
 
@@ -69,6 +70,8 @@ on_disconnect = /path/to/script.sh
 ```
 
 Use `log_buttons = true` to discover button codes for your device.
+
+`keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.
 
 ## On-device UI (MapperManager WAF)
 

--- a/config.ini
+++ b/config.ini
@@ -8,13 +8,11 @@ debounce_ms = 0
 log_buttons = true
 long_press_ms = 500
 repeat_ms = 100
-on_connect = /mnt/us/kindle-button-mapper/scripts/start-inhib.sh
-on_disconnect = /mnt/us/kindle-button-mapper/scripts/stop-inhib.sh
+keep_awake = true
 
 # [device.gamepad]
 # name = HID Device
 # uniq = AA:BB:CC:DD:EE:FF
-# path = /dev/input/event2
 # grab = false
 #
 # [device.gamepad.buttons]

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -51,7 +51,7 @@
 
         <div class="section-label">Available on /dev/input</div>
         <div id="deviceList" class="device-list"></div>
-        <button id="btnRescan" class="btn">Rescan</button>
+        <button id="btnRescan" class="btn">Refresh</button>
 
         <div class="section-label">Daemon</div>
         <div class="detail-row">
@@ -59,10 +59,10 @@
             <span id="daemonStatus" class="detail-value">--</span>
         </div>
         <div class="actions-row">
-            <button id="btnDaemonStop" class="btn btn-half">Stop</button>
-            <button id="btnDaemonStart" class="btn btn-half">Start</button>
+            <button id="btnDaemonStop" class="btn btn-third">Stop</button>
+            <button id="btnDaemonStart" class="btn btn-third">Start</button>
+            <button id="btnRestart" class="btn btn-third">Restart</button>
         </div>
-        <button id="btnRestart" class="btn">Restart</button>
     </div>
 
     <!-- Debug tab -->
@@ -70,10 +70,9 @@
         <div class="section-label">Live capture</div>
         <p class="hint">Press a button on the paired device. Use this to discover button codes.</p>
         <button id="btnLiveCapture" class="btn">Start Capture</button>
-        <div class="detail-row">
-            <span class="detail-label">Last code</span>
-            <span id="lastCode" class="detail-value detail-mono">--</span>
-        </div>
+
+        <div class="section-label">Logs</div>
+        <button id="btnLogs" class="btn">View Logs</button>
 
         <div class="section-label">Raw config</div>
         <textarea id="rawConfig" class="raw-config"></textarea>
@@ -95,8 +94,8 @@
             </div>
             <div class="detail-id-caption">ID: <span id="devDetailIdView">--</span></div>
             <div class="detail-row">
-                <span class="detail-label">Path</span>
-                <input id="devDetailPath" class="detail-input detail-mono" type="text" />
+                <span class="detail-label">MAC</span>
+                <input id="devDetailUniq" class="detail-input detail-mono" type="text" />
             </div>
             <div class="detail-row">
                 <span class="detail-label">Exclusive <button id="devDetailGrabInfo" class="info-btn" type="button">i</button></span>
@@ -105,9 +104,9 @@
             <div class="device-detail-actions">
                 <div class="actions-row">
                     <button id="btnDeviceSave"   class="btn btn-half">Save</button>
-                    <button id="btnDeviceDelete" class="btn btn-half btn-danger">Remove</button>
+                    <button id="btnDeviceCancel" class="btn btn-half">Cancel</button>
                 </div>
-                <button id="btnDeviceCancel" class="btn">Cancel</button>
+                <button id="btnDeviceDelete" class="btn btn-danger">Remove</button>
             </div>
         </div>
     </div>
@@ -118,6 +117,18 @@
             <p id="infoMessage"></p>
             <div class="dialog-buttons">
                 <button id="btnInfoClose" class="btn">OK</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Logs overlay -->
+    <div id="logsOverlay" class="overlay">
+        <div class="dialog dialog-tall dialog-wide">
+            <p>Logs</p>
+            <pre id="logsContent" class="logs-content"></pre>
+            <div class="actions-row">
+                <button id="btnLogsRefresh" class="btn btn-half">Refresh</button>
+                <button id="btnLogsClose" class="btn btn-half">Close</button>
             </div>
         </div>
     </div>

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -19,8 +19,9 @@ var MapperManager = (function() {
     var actionTab = "koreader"; // which tab is showing in the action picker
     var currentDeviceId = null; // currently selected device on Bindings tab
     var editingDeviceId = null; // device being edited in the detail overlay (null = new)
-    var devDetailUniq = "";    // uniq (MAC) carried through the detail overlay
     var continuousCapture = false; // when true, re-fire capture after each action pick
+    var deviceScanTimer = null; // Device tab auto-refresh interval
+    var lastDevicesSig = "";    // last /devices result, to skip redundant renders
 
     var DEVICE_KINDS = ["buttons", "longpress", "dpad", "dpad_longpress", "triggers", "triggers_longpress"];
 
@@ -332,7 +333,8 @@ var MapperManager = (function() {
         for (var j = 0; j < panes.length; j++) {
             panes[j].className = "tab-content" + (panes[j].id === "tab-" + name ? " tab-visible" : "");
         }
-        if (name === "device") { refreshDevices(); refreshStatus(); }
+        if (name === "device") { refreshDevices(); refreshStatus(); startDeviceAutoRefresh(); }
+        else { stopDeviceAutoRefresh(); }
         if (name === "debug") { renderRawConfig(); }
     }
 
@@ -476,12 +478,43 @@ var MapperManager = (function() {
 
     function captureNewButton(longPress) {
         if (!currentDeviceId) { showMessage("Add a device first", true); return; }
-        var devPath = getValue("device." + currentDeviceId, "path");
-        if (!devPath) {
-            showMessage("This device has no /dev/input path yet — opening editor.", true);
-            openDeviceDetail(currentDeviceId);
-            return;
-        }
+        showMessage("Finding device...", false);
+        resolveDevicePath(currentDeviceId, function(devPath, err) {
+            if (!devPath) { showMessage(err || "Device not connected", true); return; }
+            startCapture(devPath, longPress);
+        });
+    }
+
+    function resolveDevicePath(id, cb) {
+        var uniq = getValue("device." + id, "uniq") || "";
+        var name = getValue("device." + id, "name") || "";
+        getJSON("/devices", function(data, err) {
+            if (err) { cb(null, "Devices: " + err); return; }
+            var list = data.devices || [];
+            var match = null;
+            for (var i = 0; i < list.length; i++) {
+                if (uniq && list[i].uniq === uniq) {
+                    match = list[i];
+                    break;
+                }
+            }
+            if (!match && name) {
+                for (var j = 0; j < list.length; j++) {
+                    if (list[j].name === name) {
+                        match = list[j];
+                        break;
+                    }
+                }
+            }
+            if (match) {
+                cb(match.path, null);
+            } else {
+                cb(null, "Device not connected");
+            }
+        });
+    }
+
+    function startCapture(devPath, longPress) {
         showOverlay("captureOverlay");
         getEl("captureMsg").innerHTML = continuousCapture
             ? "Press a button — Cancel to stop"
@@ -675,15 +708,34 @@ var MapperManager = (function() {
 
     // ---- Device tab ----
 
-    function refreshDevices() {
-        renderConfiguredDevices();
-        showMessage("Scanning /dev/input...", false);
+    function refreshDevices(quiet) {
+        if (!quiet) {
+            renderConfiguredDevices();
+            showMessage("Scanning /dev/input...", false);
+        }
         getJSON("/devices", function(data, err) {
-            if (err) { showMessage("Devices: " + err, true); return; }
-            devices = data.devices || [];
-            renderAvailableDeviceList();
-            showMessage("Found " + devices.length + " device(s)", false);
+            if (err) { if (!quiet) showMessage("Devices: " + err, true); return; }
+            var list = data.devices || [];
+            var sig = JSON.stringify(list);
+            if (sig !== lastDevicesSig) {
+                lastDevicesSig = sig;
+                devices = list;
+                renderAvailableDeviceList();
+            }
+            if (!quiet) showMessage("Found " + list.length + " device(s)", false);
         });
+    }
+
+    function startDeviceAutoRefresh() {
+        stopDeviceAutoRefresh();
+        deviceScanTimer = setInterval(function() { refreshDevices(true); }, 4000);
+    }
+
+    function stopDeviceAutoRefresh() {
+        if (deviceScanTimer) {
+            clearInterval(deviceScanTimer);
+            deviceScanTimer = null;
+        }
     }
 
     function renderConfiguredDevices() {
@@ -692,10 +744,10 @@ var MapperManager = (function() {
         for (var i = 0; i < ids.length; i++) {
             var id = ids[i];
             var name = getValue("device." + id, "name") || id;
-            var path = getValue("device." + id, "path") || "(no path)";
+            var sub = getValue("device." + id, "uniq") || getValue("device." + id, "name") || "(no id)";
             html += '<div class="device-row" data-dev-id="' + escapeHtml(id) + '">'
                 + '<div class="device-row-name">' + escapeHtml(name) + '</div>'
-                + '<div class="device-row-path">' + escapeHtml(path) + '</div>'
+                + '<div class="device-row-path">' + escapeHtml(sub) + '</div>'
                 + '</div>';
         }
         var el = getEl("configuredDevices");
@@ -704,7 +756,7 @@ var MapperManager = (function() {
 
     function renderAvailableDeviceList() {
         // /dev/input/event* nodes. Tapping one prefills a new-device dialog
-        // with that path so the user can save it as a configured device.
+        // with its name and MAC so the user can save it as a configured device.
         var html = "";
         for (var i = 0; i < devices.length; i++) {
             var d = devices[i];
@@ -734,7 +786,7 @@ var MapperManager = (function() {
                 var path = row.getAttribute("data-avail-path");
                 var name = row.getAttribute("data-avail-name");
                 var uniq = row.getAttribute("data-avail-uniq");
-                if (path) { openDeviceDetailNew(path, name, uniq); return; }
+                if (path) { openDeviceDetailNew(name, uniq); return; }
             }
             row = row.parentNode;
         }
@@ -742,12 +794,11 @@ var MapperManager = (function() {
 
     // ---- Device detail / add dialog ----
 
-    function openDeviceDetailNew(prefillPath, prefillName, prefillUniq) {
+    function openDeviceDetailNew(prefillName, prefillUniq) {
         editingDeviceId = null;
-        devDetailUniq = prefillUniq || "";
         getEl("deviceDetailTitle").innerHTML = "New device";
         getEl("devDetailName").value = prefillName || "";
-        getEl("devDetailPath").value = prefillPath || "";
+        getEl("devDetailUniq").value = prefillUniq || "";
         getEl("devDetailGrab").className = "toggle";
         getEl("btnDeviceDelete").style.display = "none";
         updateDeviceIdView();
@@ -756,10 +807,9 @@ var MapperManager = (function() {
 
     function openDeviceDetail(id) {
         editingDeviceId = id;
-        devDetailUniq = getValue("device." + id, "uniq") || "";
         getEl("deviceDetailTitle").innerHTML = "Edit device";
         getEl("devDetailName").value = getValue("device." + id, "name") || "";
-        getEl("devDetailPath").value = getValue("device." + id, "path") || "";
+        getEl("devDetailUniq").value = getValue("device." + id, "uniq") || "";
         var grab = (getValue("device." + id, "grab") || "").toLowerCase() === "true";
         getEl("devDetailGrab").className = "toggle" + (grab ? " on" : "");
         getEl("btnDeviceDelete").style.display = "block";
@@ -791,9 +841,9 @@ var MapperManager = (function() {
             showMessage("Name needs at least one letter or digit", true);
             return;
         }
-        var path = (getEl("devDetailPath").value || "").replace(/^\s+|\s+$/g, "");
-        if (!path) {
-            showMessage("Path is required — pick one from /dev/input on the Device tab", true);
+        var uniq = (getEl("devDetailUniq").value || "").replace(/^\s+|\s+$/g, "");
+        if (!uniq && !name) {
+            showMessage("Set a name or MAC", true);
             return;
         }
         var grab = getEl("devDetailGrab").className.indexOf(" on") >= 0 ? "true" : "false";
@@ -804,9 +854,9 @@ var MapperManager = (function() {
         }
 
         setValue("device." + newId, "name", name);
-        setValue("device." + newId, "path", path);
         setValue("device." + newId, "grab", grab);
-        if (devDetailUniq) setValue("device." + newId, "uniq", devDetailUniq);
+        if (uniq) { setValue("device." + newId, "uniq", uniq); } else { delValue("device." + newId, "uniq"); }
+        delValue("device." + newId, "path");
 
         if (!currentDeviceId) currentDeviceId = newId;
         closeDeviceDetail();
@@ -887,6 +937,26 @@ var MapperManager = (function() {
         captureNewButton(false);
     }
 
+    function openLogs() {
+        getEl("logsContent").innerHTML = "Loading...";
+        showOverlay("logsOverlay");
+        request("GET", "/logs", null, function(text, err) {
+            if (err) { getEl("logsContent").innerHTML = escapeHtml("Error: " + err); return; }
+            var lines = (text || "").split("\n");
+            for (var i = 0; i < lines.length; i++) { lines[i] = formatLogLine(lines[i]); }
+            getEl("logsContent").innerHTML = escapeHtml(lines.join("\n")) || "(empty)";
+        });
+    }
+
+    function formatLogLine(line) {
+        var m = line.match(/^\[\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})Z\s+(\w+)\s+([^\]]*)\]\s?(.*)$/);
+        if (!m) return line;
+        var mod = m[3].replace(/^kindle_button_mapper(::)?/, "");
+        return m[1] + " " + m[2] + (mod ? " " + mod : "") + ": " + m[4];
+    }
+
+    function closeLogs() { hideOverlay("logsOverlay"); }
+
     // ---- Quit ----
 
     function quit() {
@@ -921,6 +991,9 @@ var MapperManager = (function() {
         getEl("btnDaemonStop").addEventListener("click", stopDaemon, false);
         getEl("btnDaemonStart").addEventListener("click", startDaemon, false);
         getEl("btnLiveCapture").addEventListener("click", liveCapture, false);
+        getEl("btnLogs").addEventListener("click", openLogs, false);
+        getEl("btnLogsRefresh").addEventListener("click", openLogs, false);
+        getEl("btnLogsClose").addEventListener("click", closeLogs, false);
         getEl("btnSaveRaw").addEventListener("click", saveRawConfig, false);
         getEl("btnCaptureCancel").addEventListener("click", cancelCapture, false);
         getEl("btnActionCancel").addEventListener("click", function() {

--- a/illusion/MapperManager/style.css
+++ b/illusion/MapperManager/style.css
@@ -307,6 +307,13 @@ html, body {
 
 .btn-half + .btn-half { float: right; }
 
+.btn-third {
+    float: left;
+    width: 32%;
+    margin-bottom: 0;
+}
+.btn-third + .btn-third { margin-left: 2%; }
+
 .actions-row { overflow: hidden; padding-top: 20px; }
 
 /* ---- Device list ---- */
@@ -416,6 +423,23 @@ html, body {
 }
 
 .dialog-tall { top: 6%; height: 88%; overflow: hidden; padding-bottom: 110px; }
+.dialog-wide { left: 2%; width: 96%; padding-bottom: 28px; }
+
+.logs-content {
+    height: 940px;
+    overflow: auto;
+    font-family: monospace;
+    font-size: 22px;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    word-break: break-all;
+    text-align: left;
+    border: 2px solid #000;
+    padding: 12px;
+    margin-bottom: 16px;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
 .dialog-tall .dialog-buttons,
 .dialog-tall .device-detail-actions {
     position: absolute;

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ cp "$SRC_DIR/kindle-button-mapper.init" "$INSTALL_DIR/"
 cp "$SRC_DIR/uninstall.sh" "$INSTALL_DIR/"
 [ -f "$INSTALL_DIR/config.ini" ] || cp "$SRC_DIR/config.ini" "$INSTALL_DIR/"
 cp "$SRC_DIR/scripts/"*.sh "$INSTALL_DIR/scripts/"
+rm -f "$INSTALL_DIR/scripts/start-inhib.sh" "$INSTALL_DIR/scripts/stop-inhib.sh"
 cp "$SRC_DIR/illusion/MapperManager.sh" "$SRC_DIR/illusion/install-waf-app.sh" "$INSTALL_DIR/illusion/"
 cp "$SRC_DIR/illusion/MapperManager/"* "$INSTALL_DIR/illusion/MapperManager/"
 

--- a/justfile
+++ b/justfile
@@ -51,8 +51,11 @@ deploy: build-kindle
     @echo "Creating directories..."
     ssh kindle "mkdir -p /mnt/us/kindle-button-mapper/scripts"
     @echo "Copying files..."
-    scp target/armv7-unknown-linux-musleabihf/release/kindle-button-mapper kindle:/mnt/us/kindle-button-mapper/
-    scp config.ini kindle:/mnt/us/kindle-button-mapper/
+    # scp can't overwrite the running binary (busy on vfat); copy to a temp name and rename.
+    scp target/armv7-unknown-linux-musleabihf/release/kindle-button-mapper kindle:/mnt/us/kindle-button-mapper/kindle-button-mapper.new
+    ssh kindle "mv -f /mnt/us/kindle-button-mapper/kindle-button-mapper.new /mnt/us/kindle-button-mapper/kindle-button-mapper && chmod +x /mnt/us/kindle-button-mapper/kindle-button-mapper"
+    @echo "Copying config (only if absent, to preserve device bindings)..."
+    ssh kindle "test -f /mnt/us/kindle-button-mapper/config.ini" || scp config.ini kindle:/mnt/us/kindle-button-mapper/
     scp scripts/*.sh kindle:/mnt/us/kindle-button-mapper/scripts/
     ssh kindle "chmod +x /mnt/us/kindle-button-mapper/scripts/*.sh"
     scp kindle-button-mapper.init kindle:/etc/init.d/kindle-button-mapper

--- a/scripts/start-inhib.sh
+++ b/scripts/start-inhib.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# Inhibit screen saver when controller connects
-
-lipc-set-prop com.lab126.powerd preventScreenSaver 1

--- a/scripts/stop-inhib.sh
+++ b/scripts/stop-inhib.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# Allow screen saver when controller disconnects
-
-lipc-set-prop com.lab126.powerd preventScreenSaver 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ pub enum Trigger {
 pub struct DeviceConfig {
     pub id: String,
     pub name: Option<String>,
-    pub path: Option<String>,
     pub uniq: Option<String>,
     pub grab: bool,
     pub mappings: HashMap<Key, String>,
@@ -40,7 +39,6 @@ impl DeviceConfig {
         Self {
             id,
             name: None,
-            path: None,
             uniq: None,
             grab: true,
             mappings: HashMap::new(),
@@ -60,6 +58,7 @@ pub struct Config {
     pub long_press_ms: u64,
     pub repeat_ms: u64,
     pub log_buttons: bool,
+    pub keep_awake: bool,
     pub on_connect: Option<String>,
     pub on_disconnect: Option<String>,
 }
@@ -72,6 +71,7 @@ impl Default for Config {
             long_press_ms: 500,
             repeat_ms: 100,
             log_buttons: false,
+            keep_awake: true,
             on_connect: None,
             on_disconnect: None,
         }
@@ -86,7 +86,12 @@ debounce_ms = 0
 log_buttons = true
 long_press_ms = 500
 repeat_ms = 100
+keep_awake = true
 ";
+
+const OLD_SECTIONS: [&str; 7] = [
+    "device", "buttons", "longpress", "dpad", "dpad_longpress", "triggers", "triggers_longpress",
+];
 
 impl Config {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, String> {
@@ -102,30 +107,21 @@ impl Config {
         let mut config = Config::default();
         let map = ini.get_map_ref();
 
-        // [settings] — global daemon settings
-        if let Some(settings) = map.get("settings") {
-            if let Some(Some(v)) = settings.get("debounce_ms") {
-                config.debounce_ms = v.parse().unwrap_or(config.debounce_ms);
-            }
-            if let Some(Some(v)) = settings.get("long_press_ms") {
-                config.long_press_ms = v.parse().unwrap_or(config.long_press_ms);
-            }
-            if let Some(Some(v)) = settings.get("repeat_ms") {
-                config.repeat_ms = v.parse().unwrap_or(config.repeat_ms);
-            }
-            if let Some(Some(v)) = settings.get("log_buttons") {
-                config.log_buttons = matches!(v.to_lowercase().as_str(), "true" | "yes" | "1");
-            }
-            if let Some(Some(v)) = settings.get("on_connect") {
-                if !v.is_empty() {
-                    config.on_connect = Some(v.clone());
-                }
-            }
-            if let Some(Some(v)) = settings.get("on_disconnect") {
-                if !v.is_empty() {
-                    config.on_disconnect = Some(v.clone());
-                }
-            }
+        if map.keys().any(|s| OLD_SECTIONS.contains(&s.as_str())) {
+            return Err(format!(
+                "{} uses the old config format. Delete it and re-add your device via the Button Mapper app.",
+                p.display()
+            ));
+        }
+
+        if let Some(s) = map.get("settings") {
+            if let Some(v) = get(s, "debounce_ms") { config.debounce_ms = v.parse().unwrap_or(config.debounce_ms); }
+            if let Some(v) = get(s, "long_press_ms") { config.long_press_ms = v.parse().unwrap_or(config.long_press_ms); }
+            if let Some(v) = get(s, "repeat_ms") { config.repeat_ms = v.parse().unwrap_or(config.repeat_ms); }
+            if let Some(v) = get(s, "log_buttons") { config.log_buttons = parse_bool(v); }
+            if let Some(v) = get(s, "keep_awake") { config.keep_awake = parse_bool(v); }
+            config.on_connect = get(s, "on_connect").filter(|v| !v.is_empty()).map(String::from);
+            config.on_disconnect = get(s, "on_disconnect").filter(|v| !v.is_empty()).map(String::from);
         }
 
         // First pass: collect device IDs from [device.NAME] sections, ordered by appearance.
@@ -165,19 +161,9 @@ impl Config {
 
             match parts.get(2).copied() {
                 None => {
-                    // [device.NAME] — device meta
-                    if let Some(Some(v)) = entries.get("name") {
-                        dev.name = Some(v.clone());
-                    }
-                    if let Some(Some(v)) = entries.get("path") {
-                        dev.path = Some(v.clone());
-                    }
-                    if let Some(Some(v)) = entries.get("uniq") {
-                        dev.uniq = Some(v.clone());
-                    }
-                    if let Some(Some(v)) = entries.get("grab") {
-                        dev.grab = matches!(v.to_lowercase().as_str(), "true" | "yes" | "1");
-                    }
+                    if let Some(v) = get(entries, "name") { dev.name = Some(v.to_string()); }
+                    if let Some(v) = get(entries, "uniq") { dev.uniq = Some(v.to_string()); }
+                    if let Some(v) = get(entries, "grab") { dev.grab = parse_bool(v); }
                 }
                 Some("buttons") => fill_key_map(entries, &mut dev.mappings),
                 Some("longpress") => fill_key_map(entries, &mut dev.long_press_mappings),
@@ -191,64 +177,24 @@ impl Config {
             }
         }
 
-        // Backward compat: flat [device] + [buttons] / [dpad] / [triggers] etc.
-        // Promote to a single device named "default".
-        if let Some(legacy) = map.get("device") {
-            // Only if the legacy section actually has device fields (path/name)
-            // *and* we didn't already see a [device.NAME] section.
-            let has_legacy_fields = legacy.contains_key("path")
-                || legacy.contains_key("name")
-                || legacy.contains_key("uniq")
-                || legacy.contains_key("grab");
-            if has_legacy_fields && devices.is_empty() {
-                let mut dev = DeviceConfig::new("default".to_string());
-                if let Some(Some(v)) = legacy.get("name") {
-                    dev.name = Some(v.clone());
-                }
-                if let Some(Some(v)) = legacy.get("path") {
-                    dev.path = Some(v.clone());
-                }
-                if let Some(Some(v)) = legacy.get("uniq") {
-                    dev.uniq = Some(v.clone());
-                }
-                if let Some(Some(v)) = legacy.get("grab") {
-                    dev.grab = matches!(v.to_lowercase().as_str(), "true" | "yes" | "1");
-                }
-                if let Some(e) = map.get("buttons") {
-                    fill_key_map(e, &mut dev.mappings);
-                }
-                if let Some(e) = map.get("longpress") {
-                    fill_key_map(e, &mut dev.long_press_mappings);
-                }
-                if let Some(e) = map.get("dpad") {
-                    fill_dpad_map(e, &mut dev.dpad_mappings);
-                }
-                if let Some(e) = map.get("dpad_longpress") {
-                    fill_dpad_map(e, &mut dev.dpad_longpress_mappings);
-                }
-                if let Some(e) = map.get("triggers") {
-                    fill_trigger_map(e, &mut dev.trigger_mappings);
-                }
-                if let Some(e) = map.get("triggers_longpress") {
-                    fill_trigger_map(e, &mut dev.trigger_longpress_mappings);
-                }
-                devices.insert("default".to_string(), dev);
-                order.push("default".to_string());
-            }
-        }
-
         for id in order {
             if let Some(dev) = devices.remove(&id) {
-                if dev.path.is_some() || dev.name.is_some() || dev.uniq.is_some() {
+                if dev.name.is_some() || dev.uniq.is_some() {
                     config.devices.push(dev);
                 }
             }
         }
 
-        // Empty device list is allowed — daemon will idle and let the
-        // WAF add devices before a restart.
         Ok(config)
     }
+}
+
+fn get<'a>(section: &'a HashMap<String, Option<String>>, key: &str) -> Option<&'a str> {
+    section.get(key).and_then(|v| v.as_deref())
+}
+
+fn parse_bool(v: &str) -> bool {
+    matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "yes" | "1" | "on")
 }
 
 fn fill_key_map(

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,7 +11,6 @@ const INPUT_DIR: &str = "/dev/input";
 
 pub struct InputHandler {
     device_name: Option<String>,
-    device_path: Option<String>,
     device_uniq: Option<String>,
     grab: bool,
 }
@@ -19,61 +18,30 @@ pub struct InputHandler {
 impl InputHandler {
     pub fn new(
         device_name: Option<String>,
-        device_path: Option<String>,
         device_uniq: Option<String>,
         grab: bool,
     ) -> Self {
         Self {
             device_name,
-            device_path,
             device_uniq,
             grab,
         }
     }
 
     pub fn open(&self) -> Result<Device, String> {
-        let has_identity = self.device_uniq.as_ref().is_some_and(|u| !u.is_empty())
-            || self.device_name.as_ref().is_some_and(|n| !n.is_empty());
+        let has_identity = self.device_uniq.as_deref().is_some_and(|u| !u.is_empty())
+            || self.device_name.as_deref().is_some_and(|n| !n.is_empty());
+        if !has_identity {
+            return Err("No device name or uniq specified".to_string());
+        }
 
-        if has_identity {
-            // Try configured path first as a quick check
-            if let Some(ref path_str) = self.device_path {
-                let path = Path::new(path_str);
-                if path.exists() {
-                    if let Ok(dev) = Device::open(path) {
-                        if self.matches_device(&dev) {
-                            return self.finish_open(dev);
-                        }
-                        debug!("Device at {} doesn't match identity, scanning...", path.display());
-                    }
-                }
-            }
-
-            if let Some(dev) = self.scan_for_device()? {
-                return self.finish_open(dev);
-            }
-
-            info!("Waiting for device to appear...");
-            let dev = self.wait_for_matching_device()?;
+        if let Some(dev) = self.scan_for_device()? {
             return self.finish_open(dev);
         }
 
-        // No identity — fall back to path-only
-        if let Some(ref path_str) = self.device_path {
-            let path = Path::new(path_str);
-            if path.exists() {
-                let dev = Device::open(path)
-                    .map_err(|e| format!("Cannot open {}: {}", path.display(), e))?;
-                return self.finish_open(dev);
-            }
-            info!("Device {} not found, waiting...", path.display());
-            self.wait_for_path(path)?;
-            let dev = Device::open(path)
-                .map_err(|e| format!("Cannot open {}: {}", path.display(), e))?;
-            return self.finish_open(dev);
-        }
-
-        Err("No device name, uniq, or path specified".to_string())
+        info!("Waiting for device to appear...");
+        let dev = self.wait_for_matching_device()?;
+        self.finish_open(dev)
     }
 
     fn matches_device(&self, dev: &Device) -> bool {
@@ -159,37 +127,6 @@ impl InputHandler {
                         Err(e) => {
                             debug!("Cannot open new device {}: {}", path.display(), e);
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    fn wait_for_path(&self, target_path: &Path) -> Result<(), String> {
-        let inotify = Inotify::init(InitFlags::empty())
-            .map_err(|e| format!("inotify_init failed: {}", e))?;
-        inotify.add_watch(Path::new(INPUT_DIR), AddWatchFlags::IN_CREATE)
-            .map_err(|e| format!("inotify_add_watch failed: {}", e))?;
-
-        let target_name = target_path.file_name()
-            .and_then(|n| n.to_str())
-            .ok_or("Invalid device path")?;
-
-        // Same race as above: the path may have appeared before the watch.
-        if target_path.exists() {
-            return Ok(());
-        }
-
-        loop {
-            let events = inotify.read_events()
-                .map_err(|e| format!("inotify read failed: {}", e))?;
-
-            for event in events {
-                if let Some(event_name) = &event.name {
-                    if event_name.to_string_lossy() == target_name {
-                        info!("Device {} appeared", target_path.display());
-                        thread::sleep(Duration::from_millis(100));
-                        return Ok(());
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,11 @@ use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
 use std::process::{self, Command};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+const KEEP_AWAKE_INTERVAL: Duration = Duration::from_secs(60);
+const KEEP_AWAKE_POKE: &str = "lipc-set-prop -i com.lab126.powerd touchScreenSaverTimeout 1";
+const KEEP_AWAKE_RELEASE: &str = "lipc-set-prop com.lab126.powerd preventScreenSaver 0";
 
 fn main() {
     env_logger::Builder::from_env(
@@ -87,19 +91,21 @@ fn main() {
     let _vkeyboard = vkeyboard::try_init();
 
     let mut handles = Vec::new();
-    let on_connect = config.on_connect.clone();
-    let on_disconnect = config.on_disconnect.clone();
+    let settings = WorkerSettings {
+        debounce_ms: config.debounce_ms,
+        long_press_ms: config.long_press_ms,
+        repeat_ms: config.repeat_ms,
+        log_buttons: config.log_buttons,
+        keep_awake: config.keep_awake,
+        on_connect: config.on_connect.clone(),
+        on_disconnect: config.on_disconnect.clone(),
+    };
     for device in config.devices {
         let id = device.id.clone();
-        let debounce_ms = config.debounce_ms;
-        let long_press_ms = config.long_press_ms;
-        let repeat_ms = config.repeat_ms;
-        let log_buttons = config.log_buttons;
-        let on_conn = on_connect.clone();
-        let on_disc = on_disconnect.clone();
+        let settings = settings.clone();
         let h = thread::Builder::new()
             .name(format!("dev:{}", id))
-            .spawn(move || device_worker(device, debounce_ms, long_press_ms, repeat_ms, log_buttons, on_conn, on_disc))
+            .spawn(move || device_worker(device, settings))
             .expect("spawn device thread");
         handles.push(h);
     }
@@ -115,29 +121,38 @@ fn main() {
     }
 }
 
-fn device_worker(
-    cfg: config::DeviceConfig,
+#[derive(Clone)]
+struct WorkerSettings {
     debounce_ms: u64,
     long_press_ms: u64,
     repeat_ms: u64,
     log_buttons: bool,
+    keep_awake: bool,
     on_connect: Option<String>,
     on_disconnect: Option<String>,
-) {
-    let mut mapper = Mapper::new(&cfg, debounce_ms, long_press_ms, repeat_ms, log_buttons);
+}
+
+fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
+    let mut mapper = Mapper::new(
+        &cfg,
+        settings.debounce_ms,
+        settings.long_press_ms,
+        settings.repeat_ms,
+        settings.log_buttons,
+    );
 
     loop {
-        let handler = InputHandler::new(cfg.name.clone(), cfg.path.clone(), cfg.uniq.clone(), cfg.grab);
+        let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
         match handler.open() {
             Ok(mut device) => {
                 info!("[{}] device connected", cfg.id);
-                if let Some(ref script) = on_connect {
+                if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab) {
+                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab, settings.keep_awake) {
                     error!("[{}] event loop error: {}", cfg.id, e);
-                    if let Some(ref script) = on_disconnect {
+                    if let Some(ref script) = settings.on_disconnect {
                         info!("[{}] device disconnected, running on_disconnect script", cfg.id);
                         execute_script(script);
                     }
@@ -152,10 +167,17 @@ fn device_worker(
     }
 }
 
-fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool) -> Result<(), String> {
+fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, keep_awake: bool) -> Result<(), String> {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
     let mut grabbed = grab;
+
+    let mut last_poke: Option<Instant> = if keep_awake {
+        execute_script(KEEP_AWAKE_RELEASE);
+        Some(Instant::now())
+    } else {
+        None
+    };
 
     loop {
         // Release the grab while capture is paused, restore it after.
@@ -194,9 +216,11 @@ fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool) -
             continue;
         }
 
+        let mut activity = false;
         for event in events {
             match event.kind() {
                 InputEventKind::Key(key) => {
+                    activity = true;
                     match event.value() {
                         1 => mapper.handle_press(key),  // Press
                         2 => mapper.handle_held(key),   // Held/repeat
@@ -208,13 +232,28 @@ fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool) -
                     let code = axis.0;
                     match code {
                         // D-pad: Hat0X (16) and Hat0Y (17)
-                        16 | 17 => mapper.handle_dpad(code, event.value()),
+                        16 | 17 => {
+                            activity = true;
+                            mapper.handle_dpad(code, event.value());
+                        }
                         // Triggers: Gas (9) = RT, Brake (10) = LT
-                        9 | 10 => mapper.handle_trigger(code, event.value()),
+                        9 | 10 => {
+                            activity = true;
+                            mapper.handle_trigger(code, event.value());
+                        }
                         _ => {}
                     }
                 }
                 _ => {}
+            }
+        }
+
+        if keep_awake && activity {
+            let now = Instant::now();
+            if last_poke.is_none_or(|t| now.duration_since(t) >= KEEP_AWAKE_INTERVAL) {
+                info!("keep-awake: re-armed screensaver idle timer");
+                execute_script(KEEP_AWAKE_POKE);
+                last_poke = Some(now);
             }
         }
     }

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -78,6 +78,7 @@ fn route(method: &str, path: &str, body: &str, config_path: &str) -> (u16, Strin
     match (method, route) {
         ("GET", "/") | ("GET", "/health") => (200, json_ok()),
         ("GET", "/status") => (200, status_json(config_path)),
+        ("GET", "/logs") => (200, logs_text()),
         ("GET", "/config") => match fs::read_to_string(config_path) {
             Ok(s) => (200, s),
             Err(_) => (200, String::new()),
@@ -273,6 +274,18 @@ fn status_json(config_path: &str) -> String {
         env!("CARGO_PKG_VERSION"),
         env!("BUILD_SHA")
     )
+}
+
+fn logs_text() -> String {
+    const LOG_PATH: &str = "/var/log/kindle-button-mapper.log";
+    match fs::read_to_string(LOG_PATH) {
+        Ok(s) => {
+            let lines: Vec<&str> = s.lines().collect();
+            let start = lines.len().saturating_sub(200);
+            lines[start..].join("\n")
+        }
+        Err(e) => format!("cannot read {}: {}", LOG_PATH, e),
+    }
 }
 
 fn capture(query: &std::collections::HashMap<String, String>) -> (u16, String) {


### PR DESCRIPTION
While a BT controller is connected the power button does nothing: the on_connect hook held powerd's `preventScreenSaver=1` for the whole connection, which inhibits the entire screensaver including the manual power button. This adds a `keep_awake` setting (default on) that resets powerd's screensaver t1 timer on input via `touchScreenSaverTimeout` (the same call KOReader's resetT1Timeout uses), re-arming the idle countdown without inhibiting anything, so the device stays awake while reading but still sleeps on the power button and on idle. The old preventScreenSaver inhibit scripts are dropped. It also simplifies config parsing, drops the unstable /dev/input path in favour of matching by MAC (daemon and WAF), and rejects the old flat config format instead of silently migrating it. Also stops `just deploy` from clobbering config.ini (copies it only if absent). Major bump to 1.0.0 since old configs no longer load.