### PR TITLE
feat(waf): warn when KOReader HTTP Inspector auto-start is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Uninstall: `ssh kindle "sh /mnt/us/kindle-button-mapper/uninstall.sh"` (the scri
 - Jailbroken Kindle (Kindle 5+ / FW 5.x).
 - Linux kernel with evdev (`/dev/input/eventX`) — present on all stock Kindles.
 - An input device the Kindle can see — e.g. a Bluetooth gamepad/remote bridged via [kindle-hid-passthrough](https://github.com/zampierilucas/kindle-hid-passthrough), or any USB OTG HID device.
-- **KOReader HTTP Inspector** (for KOReader integration): enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. The default mappings in `scripts/koreader.sh` send commands to `localhost:8080`.
+- **KOReader HTTP Inspector** (for KOReader integration): enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. The default mappings in `scripts/koreader.sh` send commands to `localhost:8080`. MapperManager warns you in the KOReader action tab when this auto-start is off.
 
 ## Hardware
 

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -153,6 +153,7 @@
                 <button class="action-tab" data-action-tab="keyboard">Keyboard</button>
                 <button class="action-tab" data-action-tab="custom">Custom</button>
             </div>
+            <div id="koreaderStatus" class="koreader-status hidden"></div>
             <input id="actionSearch" class="action-search" type="text" placeholder="Search keys..." />
             <div id="actionList" class="action-list"></div>
             <div id="actionCustom" class="action-custom">

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -583,6 +583,9 @@ var MapperManager = (function() {
         getEl("actionCustom").className = "action-custom" + (isCustom ? " visible" : "");
         getEl("actionList").style.display = isCustom ? "none" : "block";
 
+        if (actionTab === "koreader") refreshKoreaderStatus();
+        else getEl("koreaderStatus").className = "koreader-status hidden";
+
         if (isCustom) return;
 
         var items = isKbd ? filteredKeys : actions;
@@ -594,6 +597,18 @@ var MapperManager = (function() {
         var list = getEl("actionList");
         list.innerHTML = html;
         list.scrollTop = 0;
+    }
+
+    function refreshKoreaderStatus() {
+        var el = getEl("koreaderStatus");
+        el.className = "koreader-status hidden";
+        getJSON("/koreader/status", function(data, err) {
+            if (actionTab !== "koreader" || !data || err || data.autostart) return;
+            el.className = "koreader-status";
+            el.innerHTML = "KOReader HTTP Inspector is off. In KOReader, open "
+                + "<b>Tools → More Tools → HTTP Inspector → Auto start HTTP server</b> "
+                + "to use these actions.";
+        });
     }
 
     function onActionTabClick(e) {

--- a/illusion/MapperManager/style.css
+++ b/illusion/MapperManager/style.css
@@ -503,6 +503,21 @@ html, body {
 .action-search.visible { display: block; }
 .action-list.with-search { height: 68%; }
 
+.koreader-status {
+    font-size: 26px;
+    line-height: 1.3;
+    padding: 10px 12px;
+    margin-bottom: 10px;
+    border: 3px solid #000;
+    background: #000;
+    color: #fff;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.koreader-status.hidden { display: none; }
+.koreader-status b { text-decoration: underline; }
+
 .action-custom { display: none; }
 .action-custom.visible { display: block; }
 .action-custom .raw-config { min-height: 320px; }

--- a/scripts/koreader.sh
+++ b/scripts/koreader.sh
@@ -13,10 +13,13 @@
 #   event <name> [args] - Send arbitrary event
 
 KOREADER_URL="http://localhost:8080/koreader/event"
+LOG_PATH="/var/log/kindle-button-mapper.log"
 
 # Send event to KOReader
 send_event() {
-    curl -s --connect-timeout 1 "${KOREADER_URL}/$1" >/dev/null 2>&1
+    if ! curl -s --connect-timeout 1 "${KOREADER_URL}/$1" >/dev/null 2>&1; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  koreader.sh: KOReader not reachable at ${KOREADER_URL} (event '$1' dropped); KOReader may be closed, or HTTP Inspector auto-start is off." >> "$LOG_PATH" 2>/dev/null
+    fi
 }
 
 case "$1" in

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -78,6 +78,7 @@ fn route(method: &str, path: &str, body: &str, config_path: &str) -> (u16, Strin
     match (method, route) {
         ("GET", "/") | ("GET", "/health") => (200, json_ok()),
         ("GET", "/status") => (200, status_json(config_path)),
+        ("GET", "/koreader/status") => (200, koreader_status_json()),
         ("GET", "/logs") => (200, logs_text()),
         ("GET", "/config") => match fs::read_to_string(config_path) {
             Ok(s) => (200, s),
@@ -274,6 +275,21 @@ fn status_json(config_path: &str) -> String {
         env!("CARGO_PKG_VERSION"),
         env!("BUILD_SHA")
     )
+}
+
+const KOREADER_SETTINGS_PATH: &str = "/mnt/us/koreader/settings.reader.lua";
+
+fn koreader_status_json() -> String {
+    let autostart = fs::read_to_string(KOREADER_SETTINGS_PATH)
+        .map(|s| httpinspector_autostart_enabled(&s))
+        .unwrap_or(false);
+    format!("{{\"ok\":true,\"autostart\":{}}}", autostart)
+}
+
+fn httpinspector_autostart_enabled(lua: &str) -> bool {
+    lua.split_once("[\"httpinspector\"]")
+        .and_then(|(_, rest)| rest.split_once('}'))
+        .is_some_and(|(table, _)| table.contains("[\"autostart\"] = true"))
 }
 
 fn logs_text() -> String {


### PR DESCRIPTION
## What

The KOReader bindings only work when KOReader's HTTP Inspector is set to auto-start. Previously a button bound to a KOReader action would silently do nothing if that setting was off, with no hint why.

This adds a config-driven check in the MapperManager action picker:

- New `GET /koreader/status` helper endpoint reads KOReader's `settings.reader.lua` and reports whether `["httpinspector"]` has `autostart` enabled. Read-only; never writes KOReader's config.
- The **KOReader** action tab stays **silent when auto-start is on**, and shows a **warning banner with the enable steps when it is off** (`Tools → More Tools → HTTP Inspector → Auto start HTTP server`).
- `koreader.sh` now logs a line to the mapper log when it can't reach the server, so a dropped button press shows up in the WAF logs viewer instead of failing silently.

## Why config, not a port probe

A live port probe can't tell "KOReader is closed" (normal while you're configuring) apart from "misconfigured", so it would false-alarm constantly. The settings file is the stable source of truth and works whether or not KOReader is running.

## Tests

`src/waf_helper.rs` has 4 unit tests for the settings parser (on / off / missing table / cross-table isolation). Parser was also validated against a real on-device `settings.reader.lua`.

## Verified on device

Deployed to a Paperwhite and confirmed both states in the action picker:
- auto-start on → no banner
- auto-start off (temporarily simulated, then restored) → warning banner renders with the enable steps