### PR TITLE
docs: match README device docs to MAC/name matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,10 @@ Enable debug logging with `RUST_LOG=debug`.
 
 ## Configuration
 
-INI format configuration file:
+INI format configuration file. Each device is its own `[device.ID]` block with
+`[device.ID.{kind}]` subsections for the mappings:
 
 ```ini
-[device]
-name = "Device Name"
-# path = /dev/input/event2
-grab = true
-# keyboard_layout = fr   # XKB layout re-applied whenever this keyboard connects
-
 [settings]
 debounce_ms = 200
 long_press_ms = 500
@@ -52,24 +47,34 @@ keep_awake = true
 on_connect = /path/to/script.sh
 on_disconnect = /path/to/script.sh
 
-[buttons]
+[device.gamepad]
+name = Device Name
+uniq = AA:BB:CC:DD:EE:FF   # Bluetooth MAC; matched first when set
+grab = true
+# keyboard_layout = fr     # XKB layout re-applied whenever this keyboard connects
+
+[device.gamepad.buttons]
 # button_code = /path/to/script.sh
 
-[longpress]
+[device.gamepad.longpress]
 # button_code = /path/to/script.sh
 
-[dpad]
+[device.gamepad.dpad]
 # up/down/left/right = /path/to/script.sh
 
-[dpad_longpress]
+[device.gamepad.dpad_longpress]
 # up/down/left/right = /path/to/script.sh
 
-[triggers]
+[device.gamepad.triggers]
 # lt/rt = /path/to/script.sh
 
-[triggers_longpress]
+[device.gamepad.triggers_longpress]
 # lt/rt = /path/to/script.sh
 ```
+
+Devices are matched by identity, never by `/dev/input/eventX` path (that index is
+unstable across reconnects): the mapper uses the Bluetooth MAC (`uniq`) when set,
+otherwise the device `name`. Set at least one.
 
 Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to remap a Bluetooth keyboard. The mapper re-applies it on every connect, so the layout survives reconnects instead of reverting to US. Leave it unset to keep the system default.
 
@@ -95,7 +100,7 @@ ssh kindle "sh /mnt/us/kindle-button-mapper/illusion/install-waf-app.sh"   # fir
 
 The app has three tabs:
 - **Bindings** — list of current button / D-pad / trigger mappings per device. Tap *+ Add* to capture a button and pick an action. Each binding can map to a KOReader command, a keyboard key, or a custom shell command.
-- **Device** — list of configured devices. Add, edit, or remove devices and their `/dev/input/eventX` paths.
+- **Device** — list of configured devices, each matched by its Bluetooth MAC or name. Add, edit, or remove a device, or tap one seen on `/dev/input` to prefill its name and MAC.
 - **Debug** — live button capture for discovering codes, and a raw `config.ini` editor.
 
 ## Install from source


### PR DESCRIPTION
Addresses issue 1 of #4: the README and the MapperManager WAF UI disagreed on how devices are matched.

## Root cause
Documentation drift, not a code bug. The daemon (`src/input.rs` `matches_device`) matches devices by `uniq` (MAC) when set, otherwise by `name` — path-based matching was dropped back in 542b3a6. The WAF device form (Name / MAC / Exclusive / Layout) already reflects this. Only the README lagged:

- It showed `# path = /dev/input/event2` as a matcher.
- Its config example used the old flat `[device]` / `[buttons]` format that the loader now rejects outright (`OLD_SECTIONS`).
- The Device-tab description claimed you edit "their `/dev/input/eventX` paths".

## Changes
- Rewrote the Configuration example to the current `[device.ID]` / `[device.ID.buttons]` format (matches `config.ini`), dropping the `path` field and adding `uniq`.
- Added an explicit line: devices are matched by MAC (`uniq`) or `name`, never by the unstable eventX path.
- Fixed the Device-tab description to stop referencing eventX paths.

Docs-only change; no code touched.