### PR TITLE
fix(waf): close app via appmgrd stop instead of killing mesquite

### DIFF
--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -99,8 +99,12 @@ fn route(method: &str, path: &str, body: &str, config_path: &str) -> (u16, Strin
         ("POST", "/quit") => {
             std::thread::spawn(|| {
                 std::thread::sleep(Duration::from_millis(100));
-                let _ = Command::new("pkill")
-                    .args(["-TERM", "-f", "mesquite.*mappermanager"])
+                let _ = Command::new("lipc-set-prop")
+                    .args([
+                        "com.lab126.appmgrd",
+                        "stop",
+                        "app://com.lzampier.mappermanager",
+                    ])
                     .status();
                 std::process::exit(0);
             });


### PR DESCRIPTION
Closing the Button Mapper app popped a Kindle "software error" dialog. The `/quit` handler killed the mesquite process hosting the WAF app with `pkill -TERM`, so appmgrd recorded an abnormal exit and showed the error.

Ask appmgrd to stop the app instead (`lipc-set-prop com.lab126.appmgrd stop app://com.lzampier.mappermanager`), which runs the managed lifecycle and records a clean exit.

Same fix as kindle-hid-passthrough zampierilucas/kindle-hid-passthrough@2182209, where it was verified on device (`exitcode=0,abnormal_exit=0`, mesquite reaped in <2s).