### PR TITLE
fix(xkb): apply keyboard layout per-device so the framework UI honors it

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Devices are matched by identity, never by `/dev/input/eventX` path (that index i
 unstable across reconnects): the mapper uses the Bluetooth MAC (`uniq`) when set,
 otherwise the device `name`. Set at least one.
 
-Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to remap a Bluetooth keyboard. The mapper re-applies it on every connect, so the layout survives reconnects instead of reverting to US. Leave it unset to keep the system default.
+Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to remap a Bluetooth keyboard. The mapper re-applies it on every connect, so the layout survives reconnects instead of reverting to US. Leave it unset to keep the system default. The layout is loaded onto both the core keyboard and each keyboard device, so the framework UI (an XInput2 client) decodes it and not just X apps.
+
+The value is spliced into the XKB symbols include as `pc+<value>`, so multi-layout switching works by passing the raw include form, e.g. `keyboard_layout = ru+kz:2+group(alt_shift_toggle)` puts `ru` on group 1, `kz` on group 2, and toggles with Alt+Shift. Configure this in the INI file — live switching from the on-device app is not supported.
 
 Use `log_buttons = true` to discover button codes for your device.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,8 @@ fn execute_script(script: &str) {
 
 const XKB_DISPLAY: &str = ":0";
 
+const XKB_MAX_DEVICE_ID: u32 = 32;
+
 fn apply_keyboard_layout(layout: &str) {
     let keymap = format!(
         "xkb_keymap {{\n\
@@ -303,19 +305,62 @@ fn apply_keyboard_layout(layout: &str) {
          \x20 xkb_geometry {{ include \"pc(pc105)\" }};\n\
          }};\n"
     );
-    let mut child = match Command::new("xkbcomp")
-        .args(["-I/usr/share/X11/xkb", "-", XKB_DISPLAY])
+
+    // Core keymap covers Xlib clients; per-device covers the XInput2 UI.
+    if !load_keymap(&keymap, None) {
+        return;
+    }
+
+    let ids = keyboard_device_ids();
+    if ids.is_empty() {
+        warn!("no keyboard devices found to apply layout per-device");
+    }
+    for id in ids {
+        if load_keymap(&keymap, Some(id)) {
+            info!("applied keyboard layout to device {}", id);
+        }
+    }
+}
+
+fn load_keymap(keymap: &str, device_id: Option<u32>) -> bool {
+    let mut cmd = Command::new("xkbcomp");
+    cmd.arg("-I/usr/share/X11/xkb");
+    let id_str;
+    if let Some(id) = device_id {
+        id_str = id.to_string();
+        cmd.args(["-i", &id_str]);
+    }
+    let mut child = match cmd
+        .args(["-", XKB_DISPLAY])
         .stdin(Stdio::piped())
         .spawn()
     {
         Ok(c) => c,
         Err(e) => {
             error!("xkbcomp failed to start: {}", e);
-            return;
+            return false;
         }
     };
     if let Some(mut stdin) = child.stdin.take() {
         let _ = stdin.write_all(keymap.as_bytes());
     }
-    let _ = child.wait();
+    matches!(child.wait(), Ok(status) if status.success())
+}
+
+fn keyboard_device_ids() -> Vec<u32> {
+    let mut ids = Vec::new();
+    for id in 1..=XKB_MAX_DEVICE_ID {
+        let out = Command::new("xkbcomp")
+            .args(["-i", &id.to_string(), "-xkb", XKB_DISPLAY, "-"])
+            .stderr(Stdio::null())
+            .output();
+        if let Ok(out) = out {
+            if out.status.success()
+                && String::from_utf8_lossy(&out.stdout).contains("xkb_symbols")
+            {
+                ids.push(id);
+            }
+        }
+    }
+    ids
 }


### PR DESCRIPTION
## Fixes #12

Setting `keyboard_layout` (e.g. `ru`) applied the layout for X apps (AbiWord) but the Kindle framework UI kept typing English, with modifier keys printing symbols.

The layout was loaded only into the X **core** keyboard. Xlib clients read that map, but the framework UI (mesquite/WebKit) is an XInput2 client reading the **per-device** map, which Xorg's evdev InputClass pins to `us` on every hotplug. So neither the layout nor its modifier map reached the UI.

This loads the compiled keymap onto each keyboard slave device via `xkbcomp -i <id>`, in addition to the core.

Layout switching (issue point 2) is not handled in the app by design — it's an XKB group config set in the INI, e.g. `keyboard_layout = ru+kz:2+group(alt_shift_toggle)`. Documented in the README.