### PR TITLE
Use native chrome so the MapperManager status bar renders

### DIFF
--- a/illusion/MapperManager/config.xml
+++ b/illusion/MapperManager/config.xml
@@ -10,7 +10,7 @@
     <content src="index.html" />
 
     <kindle:chrome>
-        <kindle:asset key="configureSearchBar" value="none" />
+        <kindle:asset key="configureSearchBar" value="system" />
     </kindle:chrome>
 
     <kindle:gestures>

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -8,11 +8,6 @@
 </head>
 <body>
 
-    <div class="header">
-        <h1>Button Mapper</h1>
-        <button id="btnBack" class="btn-close">&#x2715;</button>
-    </div>
-
     <div id="messageBar" class="message-bar"></div>
 
     <!-- Tab bar -->

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -978,31 +978,10 @@ var MapperManager = (function() {
 
     function closeLogs() { hideOverlay("logsOverlay"); }
 
-    // ---- Quit ----
-
-    function quit() {
-        // Ask the helper to exit so we don't leave an HTTP socket bound.
-        postJSON("/quit", "", function() {});
-        if (typeof kindle !== "undefined" && kindle.appmgr) {
-            if (kindle.appmgr.startApplication) {
-                kindle.appmgr.startApplication("com.lab126.booklet.home");
-                return;
-            }
-            if (kindle.appmgr.back) {
-                kindle.appmgr.back();
-                return;
-            }
-        }
-        // Last-ditch fallback for firmwares where neither API is exposed:
-        // ask the helper to shoot the WAF via lipc.
-        request("POST", "/exit-app", null, function() {});
-    }
-
     // ---- Init ----
 
     function bindEvents() {
         bindTabs();
-        getEl("btnBack").addEventListener("click", quit, false);
         getEl("btnAdd").addEventListener("click", openAddPicker, false);
         getEl("btnAddCancel").addEventListener("click", closeAddPicker, false);
         getEl("btnSave").addEventListener("click", saveAndApply, false);


### PR DESCRIPTION
Same status bar fix as kindle-hid-passthrough, both apps share the nitpick.

MapperManager had configureSearchBar=none, so the WAF window covered the whole screen including the status bar strip and the clock, wifi and battery only appeared when a value changed. Switched to configureSearchBar=system and dropped the custom in-app header, so native chrome owns the status bar, title and close.

No binary rebuild, only the WAF assets changed. The helper keeps running after native close and gets reused on next launch via the existing PID check, so nothing leaks. The Rust /quit and /exit-app routes are unused now, I left them to avoid a rebuild, they can go next time the binary is built.

Heads up: I couldn't test this one on device, the Kindle I have button-mapper uninstalled on. It's the identical mesquite/pillow setup as the hid app though, which I did test.