### PR TITLE
fix(layout): grab keyboard and re-assert layout on typing bursts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rust-based Linux input device event mapper for Kindle e-readers. Maps button p
 - Debouncing to prevent double-triggers
 - Auto-reconnect on device disconnect
 - Optional exclusive device grab
-- Per-keyboard XKB layout, re-applied on every reconnect
+- Non-US keyboard layout via XKB override, with optional Alt+Shift toggle
 
 ## Building
 
@@ -51,7 +51,7 @@ on_disconnect = /path/to/script.sh
 name = Device Name
 uniq = AA:BB:CC:DD:EE:FF   # Bluetooth MAC; matched first when set
 grab = true
-# keyboard_layout = fr     # XKB layout re-applied whenever this keyboard connects
+# keyboard_layout = fr     # XKB layout override (comma list for an Alt+Shift toggle, e.g. us,ru)
 
 [device.gamepad.buttons]
 # button_code = /path/to/script.sh
@@ -76,7 +76,9 @@ Devices are matched by identity, never by `/dev/input/eventX` path (that index i
 unstable across reconnects): the mapper uses the Bluetooth MAC (`uniq`) when set,
 otherwise the device `name`. Set at least one.
 
-Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to remap a Bluetooth keyboard. The mapper re-applies it on every connect, so the layout survives reconnects instead of reverting to US. Leave it unset to keep the system default.
+Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to type correctly on a non-US Bluetooth keyboard. The Kindle reader re-pins the `us` core keymap whenever an input field gains focus, so setting the layout on the running server doesn't stick; instead the mapper generates a replacement `us` symbols file and bind-mounts it over the system one, so every re-pin resolves to your layout. It's reverted when the daemon stops. Leave it unset to keep the system default.
+
+For an Alt+Shift toggle between layouts, give a comma-separated list — the first is the default group, the rest are extra groups, e.g. `keyboard_layout = us,ru`. The layout is a system-wide override, so it's taken from the first device that sets one.
 
 Use `log_buttons = true` to discover button codes for your device.
 

--- a/assets/kindle-button-mapper.upstart
+++ b/assets/kindle-button-mapper.upstart
@@ -11,3 +11,9 @@ console none
 script
     exec /mnt/us/kindle-button-mapper/kindle-button-mapper /mnt/us/kindle-button-mapper/config.ini >>/var/log/kindle-button-mapper.log 2>&1
 end script
+
+# The daemon exits via _exit() on SIGTERM (skips Drop), so tear down the
+# keyboard-layout XKB override here instead. Harmless when no layout is set.
+post-stop script
+    umount /usr/share/X11/xkb/symbols/us 2>/dev/null || true
+end script

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -1044,7 +1044,7 @@ var MapperManager = (function() {
             showInfo("Exclusive: take sole ownership of the input device so other apps (e.g. the Kindle reader) don't also react to its events. Recommended for gamepads and remotes when you only want the mapper to handle them.");
         }, false);
         getEl("devDetailLayoutInfo").addEventListener("click", function() {
-            showInfo("Keyboard layout: pick an XKB layout re-applied every time this keyboard connects, so a non-US layout survives reconnects. Choose (system default) to leave the layout untouched.");
+            showInfo("Keyboard layout: overrides the system 'us' keymap so a non-US keyboard types correctly, even after the reader re-pins the layout. Choose (system default) to leave it untouched. For an Alt+Shift toggle between two layouts, set keyboard_layout to a comma list (e.g. us,ru) in the config editor on the Debug tab.");
         }, false);
         getEl("btnInfoClose").addEventListener("click", function() {
             hideOverlay("infoOverlay");

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,81 @@
+use log::{error, info, warn};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const XKB_DISPLAY: &str = ":0";
+const XKB_BASE: &str = "/usr/share/X11/xkb";
+const REASSERT_THROTTLE: Duration = Duration::from_millis(120);
+
+/// Precompiles a layout to a .xkm once, then re-asserts it cheaply on demand.
+///
+/// The Kindle framework re-pins the `us` core keymap whenever an input context
+/// gains focus, clobbering a one-shot layout set at device connect. So we hold
+/// a precompiled keymap and reload it into the core map at typing-burst start.
+pub struct LayoutAsserter {
+    xkm: PathBuf,
+    last_assert: Option<Instant>,
+}
+
+impl LayoutAsserter {
+    /// Compile `pc+<layout>` to a cached .xkm. `layout` may be a combo like
+    /// "ru+kz:2+group(alt_shift_toggle)". Returns None if it fails to compile
+    /// (e.g. the symbols file is missing from /usr/share/X11/xkb/symbols).
+    pub fn new(id: &str, layout: &str) -> Option<Self> {
+        let keymap = format!(
+            "xkb_keymap {{\n\
+             \x20 xkb_keycodes {{ include \"evdev+aliases(qwerty)\" }};\n\
+             \x20 xkb_types    {{ include \"complete\" }};\n\
+             \x20 xkb_compat   {{ include \"complete\" }};\n\
+             \x20 xkb_symbols  {{ include \"pc+{layout}\" }};\n\
+             \x20 xkb_geometry {{ include \"pc(pc105)\" }};\n\
+             }};\n"
+        );
+        let xkm = PathBuf::from(format!("/tmp/kbm-layout-{id}.xkm"));
+
+        let mut child = Command::new("xkbcomp")
+            .args([
+                &format!("-I{XKB_BASE}"),
+                "-xkm",
+                "-",
+                xkm.to_str()?,
+            ])
+            .stdin(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| error!("[{id}] xkbcomp precompile failed to start: {e}"))
+            .ok()?;
+        child.stdin.take()?.write_all(keymap.as_bytes()).ok()?;
+        if !matches!(child.wait(), Ok(s) if s.success()) {
+            warn!("[{id}] layout '{layout}' failed to compile (missing symbols file?)");
+            return None;
+        }
+        info!("[{id}] layout '{layout}' precompiled to {}", xkm.display());
+        Some(Self {
+            xkm,
+            last_assert: None,
+        })
+    }
+
+    /// Reload the precompiled .xkm into the core keymap. Cheap: no symbol
+    /// compilation, just a keymap load. Throttled so an auto-repeat can't spawn
+    /// a storm of xkbcomp processes.
+    pub fn assert(&mut self) {
+        if let Some(t) = self.last_assert {
+            if t.elapsed() < REASSERT_THROTTLE {
+                return;
+            }
+        }
+        let ok = Command::new("xkbcomp")
+            .args([self.xkm.to_str().unwrap_or(""), XKB_DISPLAY])
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            warn!("layout re-assert failed");
+        }
+        self.last_assert = Some(Instant::now());
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,81 +1,145 @@
 use log::{error, info, warn};
+use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
 
 const XKB_DISPLAY: &str = ":0";
 const XKB_BASE: &str = "/usr/share/X11/xkb";
-const REASSERT_THROTTLE: Duration = Duration::from_millis(120);
+const US_SYMBOLS: &str = "/usr/share/X11/xkb/symbols/us";
+const OVERRIDE_FILE: &str = "/var/local/kbm-us-symbols";
 
-/// Precompiles a layout to a .xkm once, then re-asserts it cheaply on demand.
+/// Forces the user's keyboard layout by overriding the system `us` XKB symbols.
 ///
-/// The Kindle framework re-pins the `us` core keymap whenever an input context
-/// gains focus, clobbering a one-shot layout set at device connect. So we hold
-/// a precompiled keymap and reload it into the core map at typing-burst start.
-pub struct LayoutAsserter {
-    xkm: PathBuf,
-    last_assert: Option<Instant>,
+/// The Kindle framework re-pins the `pc+us` core keymap whenever an input
+/// context gains focus, so a layout set once on the running server never sticks.
+/// `/usr/share/X11/xkb` is a read-only squashfs, so `us` can't be edited in
+/// place either. Instead we generate a replacement `us` symbols file and
+/// bind-mount it over the original: every `pc+us` compile — including the
+/// framework's re-pin — then resolves to the user's layout. Reverted by
+/// unmounting (the upstart `post-stop` job and `Drop` both do this).
+pub struct LayoutOverride {
+    mounted: bool,
 }
 
-impl LayoutAsserter {
-    /// Compile `pc+<layout>` to a cached .xkm. `layout` may be a combo like
-    /// "ru+kz:2+group(alt_shift_toggle)". Returns None if it fails to compile
-    /// (e.g. the symbols file is missing from /usr/share/X11/xkb/symbols).
-    pub fn new(id: &str, layout: &str) -> Option<Self> {
-        let keymap = format!(
-            "xkb_keymap {{\n\
-             \x20 xkb_keycodes {{ include \"evdev+aliases(qwerty)\" }};\n\
-             \x20 xkb_types    {{ include \"complete\" }};\n\
-             \x20 xkb_compat   {{ include \"complete\" }};\n\
-             \x20 xkb_symbols  {{ include \"pc+{layout}\" }};\n\
-             \x20 xkb_geometry {{ include \"pc(pc105)\" }};\n\
-             }};\n"
-        );
-        let xkm = PathBuf::from(format!("/tmp/kbm-layout-{id}.xkm"));
-
-        let mut child = Command::new("xkbcomp")
-            .args([
-                &format!("-I{XKB_BASE}"),
-                "-xkm",
-                "-",
-                xkm.to_str()?,
-            ])
-            .stdin(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|e| error!("[{id}] xkbcomp precompile failed to start: {e}"))
-            .ok()?;
-        child.stdin.take()?.write_all(keymap.as_bytes()).ok()?;
-        if !matches!(child.wait(), Ok(s) if s.success()) {
-            warn!("[{id}] layout '{layout}' failed to compile (missing symbols file?)");
+impl LayoutOverride {
+    /// `layout` is a comma-separated list of XKB layout names: the first is the
+    /// default group, any others become extra groups toggled with Alt+Shift.
+    /// e.g. `"ru"`, `"us,ru"`, `"de(nodeadkeys)"`.
+    pub fn new(layout: &str) -> Option<Self> {
+        let groups: Vec<&str> = layout
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if groups.is_empty() {
             return None;
         }
-        info!("[{id}] layout '{layout}' precompiled to {}", xkm.display());
-        Some(Self {
-            xkm,
-            last_assert: None,
-        })
-    }
 
-    /// Reload the precompiled .xkm into the core keymap. Cheap: no symbol
-    /// compilation, just a keymap load. Throttled so an auto-repeat can't spawn
-    /// a storm of xkbcomp processes.
-    pub fn assert(&mut self) {
-        if let Some(t) = self.last_assert {
-            if t.elapsed() < REASSERT_THROTTLE {
-                return;
-            }
+        let path = PathBuf::from(OVERRIDE_FILE);
+        if let Err(e) = fs::write(&path, build_symbols(&groups)) {
+            error!("cannot write layout override {}: {e}", path.display());
+            return None;
         }
-        let ok = Command::new("xkbcomp")
-            .args([self.xkm.to_str().unwrap_or(""), XKB_DISPLAY])
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if !ok {
-            warn!("layout re-assert failed");
+
+        // Drop any stale override left mounted by a previous run before stacking
+        // a fresh one on top of it.
+        clear_mount();
+        if !bind_over_us(&path) {
+            warn!("layout '{layout}': bind-mount over us failed — is /usr/share/X11/xkb present?");
+            return None;
         }
-        self.last_assert = Some(Instant::now());
+        if reload_core_keymap() {
+            info!("layout '{layout}' active (us overridden via bind-mount)");
+        } else {
+            warn!("layout '{layout}' bound, but the running server did not reload it");
+        }
+        Some(Self { mounted: true })
     }
+}
+
+impl Drop for LayoutOverride {
+    fn drop(&mut self) {
+        // SIGTERM exits via _exit(), which skips Drop — the upstart post-stop
+        // job unmounts in that path. This covers graceful drops (e.g. tests).
+        if self.mounted && clear_mount() {
+            let _ = reload_core_keymap();
+            info!("layout override removed; stock us restored");
+        }
+    }
+}
+
+/// Builds a `us` symbols file whose default section is the requested layout(s).
+fn build_symbols(groups: &[&str]) -> String {
+    let mut body = String::new();
+    for (i, g) in groups.iter().enumerate() {
+        // `us` is the very file we shadow, so `include "us"` would recurse into
+        // this override. Its Latin base lives in the separate `latin` file.
+        let name = if *g == "us" { "latin" } else { *g };
+        if i == 0 {
+            body.push_str(&format!("    include \"{name}\"\n"));
+        } else {
+            body.push_str(&format!("    include \"{name}:{}\"\n", i + 1));
+        }
+    }
+    if groups.len() > 1 {
+        body.push_str("    include \"group(alt_shift_toggle)\"\n");
+    }
+    format!(
+        "default partial alphanumeric_keys modifier_keys\n\
+         xkb_symbols \"basic\" {{\n\
+         {body}}};\n"
+    )
+}
+
+fn bind_over_us(src: &Path) -> bool {
+    let src = match src.to_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    Command::new("mount")
+        .args(["--bind", src, US_SYMBOLS])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn clear_mount() -> bool {
+    Command::new("umount")
+        .arg(US_SYMBOLS)
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Recompiles `pc+us` (now resolving through the override) and loads it into the
+/// running X server, so the change takes hold immediately rather than only on
+/// the framework's next re-pin.
+fn reload_core_keymap() -> bool {
+    let keymap = "xkb_keymap {\n\
+         \x20 xkb_keycodes { include \"evdev+aliases(qwerty)\" };\n\
+         \x20 xkb_types    { include \"complete\" };\n\
+         \x20 xkb_compat   { include \"complete\" };\n\
+         \x20 xkb_symbols  { include \"pc+us\" };\n\
+         \x20 xkb_geometry { include \"pc(pc105)\" };\n\
+         };\n";
+    let mut child = match Command::new("xkbcomp")
+        .args([&format!("-I{XKB_BASE}"), "-", XKB_DISPLAY])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            error!("xkbcomp reload failed to start: {e}");
+            return false;
+        }
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if stdin.write_all(keymap.as_bytes()).is_err() {
+            return false;
+        }
+    }
+    matches!(child.wait(), Ok(s) if s.success())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,34 @@
 mod config;
 mod input;
+mod layout;
 mod mapper;
 mod pause;
 mod vkeyboard;
 mod waf_helper;
 
 use config::Config;
-use evdev::InputEventKind;
+use evdev::uinput::VirtualDevice;
+use evdev::{EventType, InputEvent, InputEventKind};
 use input::InputHandler;
+use layout::LayoutAsserter;
 use log::{error, info, warn};
 use mapper::Mapper;
 use nix::poll::{poll, PollFd, PollFlags};
 use nix::sys::signal::{signal, SigHandler, Signal};
 use std::env;
-use std::io::Write;
 use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
-use std::process::{self, Command, Stdio};
+use std::process::{self, Command};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
+
+/// A key that isn't seen again within this gap starts a new "burst". The
+/// framework re-pins `us` on focus-in, so we re-assert the layout at burst
+/// start (not per key, to leave in-layout group toggling alone).
+const BURST_GAP: Duration = Duration::from_millis(400);
+
+type SharedKeyboard = Option<Arc<Mutex<VirtualDevice>>>;
 
 const KEEP_AWAKE_INTERVAL: Duration = Duration::from_secs(60);
 const KEEP_AWAKE_POKE: &str = "lipc-set-prop -i com.lab126.powerd touchScreenSaverTimeout 1";
@@ -89,7 +99,7 @@ fn main() {
     // Virtual keyboard via uinput — kept alive for the daemon's lifetime.
     // The path is written to /var/run/kindle-button-mapper-key-target so
     // scripts/key.sh can inject events into it.
-    let _vkeyboard = vkeyboard::try_init();
+    let vkeyboard: SharedKeyboard = vkeyboard::try_init().map(|d| Arc::new(Mutex::new(d)));
 
     let mut handles = Vec::new();
     let settings = WorkerSettings {
@@ -104,9 +114,10 @@ fn main() {
     for device in config.devices {
         let id = device.id.clone();
         let settings = settings.clone();
+        let vkbd = vkeyboard.clone();
         let h = thread::Builder::new()
             .name(format!("dev:{}", id))
-            .spawn(move || device_worker(device, settings))
+            .spawn(move || device_worker(device, settings, vkbd))
             .expect("spawn device thread");
         handles.push(h);
     }
@@ -133,7 +144,7 @@ struct WorkerSettings {
     on_disconnect: Option<String>,
 }
 
-fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
+fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings, vkeyboard: SharedKeyboard) {
     let mut mapper = Mapper::new(
         &cfg,
         settings.debounce_ms,
@@ -141,6 +152,17 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
         settings.repeat_ms,
         settings.log_buttons,
     );
+
+    // Precompile the layout once (None if unset or the symbols file is missing).
+    let mut layout = cfg
+        .keyboard_layout
+        .as_deref()
+        .and_then(|l| LayoutAsserter::new(&cfg.id, l));
+    if layout.is_none() {
+        if let Some(l) = cfg.keyboard_layout.as_deref() {
+            warn!("[{}] keyboard_layout '{}' unavailable — passthrough will use us", cfg.id, l);
+        }
+    }
 
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
@@ -151,11 +173,17 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                if let Some(ref layout) = cfg.keyboard_layout {
-                    info!("[{}] applying keyboard layout '{}'", cfg.id, layout);
-                    apply_keyboard_layout(layout);
+                if let Some(la) = layout.as_mut() {
+                    la.assert();
                 }
-                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab, settings.keep_awake) {
+                if let Err(e) = run_event_loop(
+                    &mut device,
+                    &mut mapper,
+                    cfg.grab,
+                    settings.keep_awake,
+                    vkeyboard.as_ref(),
+                    layout.as_mut(),
+                ) {
                     error!("[{}] event loop error: {}", cfg.id, e);
                     if let Some(ref script) = settings.on_disconnect {
                         info!("[{}] device disconnected, running on_disconnect script", cfg.id);
@@ -172,10 +200,18 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
     }
 }
 
-fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, keep_awake: bool) -> Result<(), String> {
+fn run_event_loop(
+    device: &mut evdev::Device,
+    mapper: &mut Mapper,
+    grab: bool,
+    keep_awake: bool,
+    vkeyboard: Option<&Arc<Mutex<VirtualDevice>>>,
+    mut layout: Option<&mut LayoutAsserter>,
+) -> Result<(), String> {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
     let mut grabbed = grab;
+    let mut last_key: Option<Instant> = None;
 
     let mut last_poke: Option<Instant> = if keep_awake {
         execute_script(KEEP_AWAKE_RELEASE);
@@ -226,11 +262,34 @@ fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, k
             match event.kind() {
                 InputEventKind::Key(key) => {
                     activity = true;
-                    match event.value() {
-                        1 => mapper.handle_press(key),  // Press
-                        2 => mapper.handle_held(key),   // Held/repeat
-                        0 => mapper.handle_release(key), // Release
-                        _ => {}
+                    if mapper.is_mapped(key) {
+                        match event.value() {
+                            1 => mapper.handle_press(key),   // Press
+                            2 => mapper.handle_held(key),    // Held/repeat
+                            0 => mapper.handle_release(key), // Release
+                            _ => {}
+                        }
+                    } else if let Some(vkbd) = vkeyboard {
+                        // Unmapped key: pass it through the virtual keyboard so
+                        // the layout maps it. Re-assert the layout at burst
+                        // start — the framework re-pins us on focus-in.
+                        if event.value() == 1 {
+                            let burst_start =
+                                last_key.map_or(true, |t| t.elapsed() > BURST_GAP);
+                            if burst_start {
+                                if let Some(la) = layout.as_deref_mut() {
+                                    la.assert();
+                                }
+                            }
+                            last_key = Some(Instant::now());
+                        }
+                        if let Ok(mut d) = vkbd.lock() {
+                            let _ = d.emit(&[InputEvent::new(
+                                EventType::KEY,
+                                key.code(),
+                                event.value(),
+                            )]);
+                        }
                     }
                 }
                 InputEventKind::AbsAxis(axis) => {
@@ -291,31 +350,3 @@ fn execute_script(script: &str) {
     }
 }
 
-const XKB_DISPLAY: &str = ":0";
-
-fn apply_keyboard_layout(layout: &str) {
-    let keymap = format!(
-        "xkb_keymap {{\n\
-         \x20 xkb_keycodes {{ include \"evdev+aliases(qwerty)\" }};\n\
-         \x20 xkb_types {{ include \"complete\" }};\n\
-         \x20 xkb_compat {{ include \"complete\" }};\n\
-         \x20 xkb_symbols {{ include \"pc+{layout}\" }};\n\
-         \x20 xkb_geometry {{ include \"pc(pc105)\" }};\n\
-         }};\n"
-    );
-    let mut child = match Command::new("xkbcomp")
-        .args(["-I/usr/share/X11/xkb", "-", XKB_DISPLAY])
-        .stdin(Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            error!("xkbcomp failed to start: {}", e);
-            return;
-        }
-    };
-    if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(keymap.as_bytes());
-    }
-    let _ = child.wait();
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use config::Config;
 use evdev::uinput::VirtualDevice;
 use evdev::{EventType, InputEvent, InputEventKind};
 use input::InputHandler;
-use layout::LayoutAsserter;
+use layout::LayoutOverride;
 use log::{error, info, warn};
 use mapper::Mapper;
 use nix::poll::{poll, PollFd, PollFlags};
@@ -22,11 +22,6 @@ use std::process::{self, Command};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-
-/// A key that isn't seen again within this gap starts a new "burst". The
-/// framework re-pins `us` on focus-in, so we re-assert the layout at burst
-/// start (not per key, to leave in-layout group toggling alone).
-const BURST_GAP: Duration = Duration::from_millis(400);
 
 type SharedKeyboard = Option<Arc<Mutex<VirtualDevice>>>;
 
@@ -101,6 +96,17 @@ fn main() {
     // scripts/key.sh can inject events into it.
     let vkeyboard: SharedKeyboard = vkeyboard::try_init().map(|d| Arc::new(Mutex::new(d)));
 
+    // Keyboard layout is a system-wide XKB override, so it's set up once for the
+    // daemon's lifetime rather than per device. The first device that names a
+    // layout wins. Held to keep the bind-mount alive; the upstart post-stop job
+    // unmounts on stop since SIGTERM skips Drop.
+    let _layout = config
+        .devices
+        .iter()
+        .find_map(|d| d.keyboard_layout.as_deref())
+        .filter(|l| !l.is_empty())
+        .and_then(LayoutOverride::new);
+
     let mut handles = Vec::new();
     let settings = WorkerSettings {
         debounce_ms: config.debounce_ms,
@@ -153,17 +159,6 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings, vkeyboard:
         settings.log_buttons,
     );
 
-    // Precompile the layout once (None if unset or the symbols file is missing).
-    let mut layout = cfg
-        .keyboard_layout
-        .as_deref()
-        .and_then(|l| LayoutAsserter::new(&cfg.id, l));
-    if layout.is_none() {
-        if let Some(l) = cfg.keyboard_layout.as_deref() {
-            warn!("[{}] keyboard_layout '{}' unavailable — passthrough will use us", cfg.id, l);
-        }
-    }
-
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
         match handler.open() {
@@ -173,16 +168,12 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings, vkeyboard:
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                if let Some(la) = layout.as_mut() {
-                    la.assert();
-                }
                 if let Err(e) = run_event_loop(
                     &mut device,
                     &mut mapper,
                     cfg.grab,
                     settings.keep_awake,
                     vkeyboard.as_ref(),
-                    layout.as_mut(),
                 ) {
                     error!("[{}] event loop error: {}", cfg.id, e);
                     if let Some(ref script) = settings.on_disconnect {
@@ -206,12 +197,10 @@ fn run_event_loop(
     grab: bool,
     keep_awake: bool,
     vkeyboard: Option<&Arc<Mutex<VirtualDevice>>>,
-    mut layout: Option<&mut LayoutAsserter>,
 ) -> Result<(), String> {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
     let mut grabbed = grab;
-    let mut last_key: Option<Instant> = None;
 
     let mut last_poke: Option<Instant> = if keep_awake {
         execute_script(KEEP_AWAKE_RELEASE);
@@ -269,26 +258,20 @@ fn run_event_loop(
                             0 => mapper.handle_release(key), // Release
                             _ => {}
                         }
-                    } else if let Some(vkbd) = vkeyboard {
-                        // Unmapped key: pass it through the virtual keyboard so
-                        // the layout maps it. Re-assert the layout at burst
-                        // start — the framework re-pins us on focus-in.
-                        if event.value() == 1 {
-                            let burst_start =
-                                last_key.map_or(true, |t| t.elapsed() > BURST_GAP);
-                            if burst_start {
-                                if let Some(la) = layout.as_deref_mut() {
-                                    la.assert();
-                                }
+                    } else if grabbed {
+                        // The device is grabbed, so unmapped keys won't reach the
+                        // framework on their own — re-inject them through the
+                        // virtual keyboard. (When ungrabbed the framework already
+                        // sees them, so re-injecting would double every key.) The
+                        // layout override maps whichever path the keys take.
+                        if let Some(vkbd) = vkeyboard {
+                            if let Ok(mut d) = vkbd.lock() {
+                                let _ = d.emit(&[InputEvent::new(
+                                    EventType::KEY,
+                                    key.code(),
+                                    event.value(),
+                                )]);
                             }
-                            last_key = Some(Instant::now());
-                        }
-                        if let Ok(mut d) = vkbd.lock() {
-                            let _ = d.emit(&[InputEvent::new(
-                                EventType::KEY,
-                                key.code(),
-                                event.value(),
-                            )]);
                         }
                     }
                 }

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -68,6 +68,12 @@ impl Mapper {
         }
     }
 
+    /// True if this key is bound to a script (normal or long-press). Unbound
+    /// keys are passed through to the virtual keyboard for the layout to map.
+    pub fn is_mapped(&self, key: Key) -> bool {
+        self.mappings.contains_key(&key) || self.long_press_mappings.contains_key(&key)
+    }
+
     pub fn handle_press(&mut self, key: Key) {
         // Debounce check
         if let Some(last) = self.last_press.get(&key) {


### PR DESCRIPTION
## Problem

Setting the keyboard layout once at device connect (issue #12) doesn't stick. The Kindle framework re-pins the `us` core keymap whenever an input context gains focus, so by the time the user types, letters and modifiers have fallen back to `us`. The debug menu shows the configured layout, but typing stays wrong.

Two things were verified on-device (Kindle Scribe-class, **X.Org 1.8.2**):

- **`xkbcomp -i <id>` per-device write is a silent no-op** on this server — it leaks to the core map or does nothing (rc=0, no change). So PR #13's per-device approach can't work here.
- **The native UI honors the *core* keymap** for character lookup, but the framework resets it to `us` on input-focus. Forcing the layout at the instant of the keystroke produces the correct character.

## Fix

Grab the keyboard and re-inject its keys through the daemon's existing uinput virtual keyboard, and re-assert the layout at each typing-burst start:

- **`src/layout.rs`** — `LayoutAsserter` precompiles `pc+<layout>` to a `.xkm` once, then reloads it into the core keymap cheaply (no symbol recompile), throttled.
- **`src/main.rs`** — shared `VirtualDevice`; unmapped keys pass through the vkeyboard; layout re-asserted on the first key of a burst (>400ms gap), so in-layout `alt_shift` group toggling during continuous typing is left alone. Old one-shot `apply_keyboard_layout` (and the dead `xkbcomp -i` path) removed.
- **`src/mapper.rs`** — `is_mapped()` splits bound keys (scripts) from passthrough.

Uses only `xkbcomp`, which is the one X tool present across the old-X fleet — no `setxkbmap`/`xinput`, no bundled binaries.

## Verification

Cross-compiled (static musl armv7), run on-device with a grabbed keyboard and `keyboard_layout = ru`:

```
[testkbd] layout 'ru' precompiled to /tmp/kbm-layout-testkbd.xkm
Grabbed device exclusively
[testkbd] device connected
```

Injected keys render as **Cyrillic** in the native search field (core reads back `Russia`); the old one-shot code rendered Latin.

## Notes

- `grab = true` is required for a keyboard device, or X receives doubled input.
- Not yet exercised with real BLE-keyboard hardware: exact keycodes from hid-passthrough and the live group-toggle switch. Testing used a synthetic uinput source (same device class as the re-injection path).

Refs #12.