### PR TITLE
fix(waf): report daemon status via initctl, not a phantom pidfile

### DIFF
--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -3,7 +3,6 @@ use log::{error, info, warn};
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::Path;
 use std::process::Command;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -294,11 +293,7 @@ fn layouts_json() -> String {
 }
 
 fn status_json(config_path: &str) -> String {
-    let pid = fs::read_to_string("/var/run/kindle-button-mapper.pid")
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok())
-        .unwrap_or(0);
-    let running = pid != 0 && Path::new(&format!("/proc/{}", pid)).exists();
+    let (running, pid) = daemon_status();
     format!(
         "{{\"ok\":true,\"running\":{},\"pid\":{},\"config\":\"{}\",\"version\":\"{}\",\"build\":\"{}\"}}",
         running,
@@ -422,6 +417,29 @@ fn capture(query: &std::collections::HashMap<String, String>) -> (u16, String) {
     }
     drop(lock);
     (200, json_err("timeout"))
+}
+
+// The daemon runs as an upstart service, which — unlike the old SysV init
+// script — writes no pidfile. Ask upstart directly instead of stat-ing a
+// pidfile that never gets created.
+fn daemon_status() -> (bool, u32) {
+    let output = match Command::new(INITCTL).args(["status", SERVICE]).output() {
+        Ok(o) => o,
+        Err(_) => return (false, 0),
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    // e.g. "kindle-button-mapper start/running, process 1234"
+    let running = text.contains("start/running");
+    if !running {
+        return (false, 0);
+    }
+    let pid = text
+        .rsplit("process ")
+        .next()
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+    (true, pid)
 }
 
 fn run_initctl(action: &str) -> (u16, String) {


### PR DESCRIPTION
## Problem

The WAF app's **Device** tab shows `DAEMON Status: not running` even when the daemon is running fine. Reported by @Monschtrum on #96 as "the daemon no longer starts (since the update)" — but their own log dump proves the daemon *is* up:

```
INFO input: Found device at /dev/input/event3
INFO input: Grabbed device exclusively
INFO input: Reading events from E2 Control Keyboard
INFO: [e2_control_keyboard] device connected
```

## Cause

`status_json` decided running-state by reading `/var/run/kindle-button-mapper.pid`. The old SysV init script wrote that pidfile (`echo $! > $PIDFILE`), but the init.d → upstart migration (`1fe0ba4`, shipped in v1.2.0) deleted that script. The upstart job just `exec`s the binary and the daemon writes no pidfile, so the read always returned 0 → `running=false` permanently. Classic false negative, matching the "since the update" report.

## Fix

Ask upstart directly (`initctl status kindle-button-mapper`), mirroring how start/stop/restart already drive the service through `initctl`. No pidfile needed.

## Testing

- `cargo build` / `cargo clippy` clean.
- Parses the upstart `start/running, process <pid>` line for the live pid; returns `(false, 0)` for `stop/waiting` or if `initctl` is absent.

Refs #96