### PR TITLE
fix(install): register upstart job with reload-configuration

### DIFF
--- a/docs/kindleforge/install.sh
+++ b/docs/kindleforge/install.sh
@@ -27,6 +27,9 @@ sh "$INSTALL_DIR/illusion/install-waf-app.sh" || true
 
 /usr/sbin/mntroot ro || true
 
+# upstart only picks up a newly dropped .conf after a config reload; without
+# this the job stays "Unknown" (so the start below fails) until a reboot.
+/sbin/initctl reload-configuration || true
 /sbin/initctl start kindle-button-mapper || true
 
 rm -rf "$TMPDIR"

--- a/docs/kindleforge/uninstall.sh
+++ b/docs/kindleforge/uninstall.sh
@@ -11,6 +11,9 @@ APP_ID="com.lzampier.mappermanager"
 /usr/sbin/mntroot rw
 
 rm -f /etc/upstart/kindle-button-mapper.conf
+# Drop the job from upstart now that its .conf is gone, so it isn't left as a
+# known-but-fileless job until the next reboot.
+/sbin/initctl reload-configuration 2>/dev/null || true
 
 if [ -f "$APPREG_DB" ]; then
     sqlite3 "$APPREG_DB" <<EOF

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,9 @@ sh "$INSTALL_DIR/illusion/install-waf-app.sh" || true
 
 /usr/sbin/mntroot ro || true
 
+# upstart only picks up a newly dropped .conf after a config reload; without
+# this the job stays "Unknown" (so the start below fails) until a reboot.
+/sbin/initctl reload-configuration || true
 /sbin/initctl restart kindle-button-mapper || /sbin/initctl start kindle-button-mapper
 
 echo "Installed. Open Button Mapper from the Kindle library or via:"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,6 +17,9 @@ sleep 1
 /usr/sbin/mntroot rw
 
 rm -f /etc/upstart/kindle-button-mapper.conf
+# Drop the job from upstart now that its .conf is gone, so it isn't left as a
+# known-but-fileless job until the next reboot.
+/sbin/initctl reload-configuration 2>/dev/null || true
 
 if [ -f "$APPREG_DB" ]; then
     sqlite3 "$APPREG_DB" <<EOF


### PR DESCRIPTION
## Problem

On a fresh install without a reboot the daemon never runs. `initctl status`/the WAF app show `not running`, there's no button mapping and no keyboard-layout override, and the log has:

```
initctl: Unknown job: kindle-button-mapper
```

Surfaced by @mergen3107 while testing #15 on a Scribe: correct build (`29955f1`), config `keyboard_layout = us,ru`, but `mount | grep symbols/us` empty because the daemon that sets up the override was never started.

## Cause

`install.sh` and `docs/kindleforge/install.sh` copy `kindle-button-mapper.conf` into `/etc/upstart/` and then run `initctl start`, but never `initctl reload-configuration`. Upstart doesn't pick up a newly dropped `.conf` until a reload (or reboot), so the job stays `Unknown` and the `start` fails silently. The old SysV script started the daemon directly, so this only regressed with the init.d → upstart migration.

## Fix

- `initctl reload-configuration` after copying the `.conf` (before `start`) in both installers.
- Same in both uninstallers after removing the `.conf`, so upstart doesn't keep a fileless job until reboot.

`sh -n` clean on all four scripts. `reload-configuration` is standard upstart (already driven via `initctl` elsewhere).

Refs #96