### PR TITLE
fix: sanitize device names from the kernel

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -163,7 +163,11 @@ impl Config {
 
             match parts.get(2).copied() {
                 None => {
-                    if let Some(v) = get(entries, "name") { dev.name = Some(v.to_string()); }
+                    // Clean here too: configs written before this existed may
+                    // still hold a U+FFFD-mangled name.
+                    dev.name = get(entries, "name")
+                        .map(clean_device_name)
+                        .filter(|v| !v.is_empty());
                     if let Some(v) = get(entries, "uniq") { dev.uniq = Some(v.to_string()); }
                     if let Some(v) = get(entries, "grab") { dev.grab = parse_bool(v); }
                     dev.keyboard_layout = get(entries, "keyboard_layout")
@@ -193,6 +197,20 @@ impl Config {
 
         Ok(config)
     }
+}
+
+/// Kernel device names are raw bytes; evdev decodes them lossily, so junk from
+/// the manufacturer arrives as NULs, control chars or U+FFFD. Strip it so every
+/// path (scan, config, UI) produces the same string for the same device.
+pub fn clean_device_name(s: &str) -> String {
+    s.split('\0')
+        .next()
+        .unwrap_or("")
+        .chars()
+        .filter(|c| *c != '\u{fffd}' && !c.is_control())
+        .collect::<String>()
+        .trim()
+        .to_string()
 }
 
 fn get<'a>(section: &'a HashMap<String, Option<String>>, key: &str) -> Option<&'a str> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+use crate::config::clean_device_name;
 use evdev::Device;
 use log::{debug, info, warn};
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
@@ -22,7 +23,7 @@ impl InputHandler {
         grab: bool,
     ) -> Self {
         Self {
-            device_name,
+            device_name: device_name.map(|n| clean_device_name(&n)),
             device_uniq,
             grab,
         }
@@ -57,7 +58,7 @@ impl InputHandler {
         }
         if let Some(ref name) = self.device_name {
             if !name.is_empty() {
-                return dev.name().unwrap_or("") == name.as_str();
+                return clean_device_name(dev.name().unwrap_or("")) == *name;
             }
         }
         true

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -1,3 +1,4 @@
+use crate::config::clean_device_name;
 use evdev::{Device, InputEventKind};
 use log::{error, info, warn};
 use std::fs;
@@ -239,7 +240,7 @@ fn devices_json() -> String {
             let (dev_name, dev_uniq) = Device::open(&path)
                 .ok()
                 .map(|d| {
-                    let n = d.name().unwrap_or("").to_string();
+                    let n = clean_device_name(d.name().unwrap_or(""));
                     let u = d.unique_name().unwrap_or("").to_string();
                     (n, u)
                 })


### PR DESCRIPTION
Devices whose manufacturer name carries NULs, control chars, or bytes evdev lossily decodes to U+FFFD ended up with a different string on each path — the scan, the WAF device list, and `config.ini` — so name-based matching silently failed.

Adds `clean_device_name()` (truncate at NUL, drop U+FFFD and control chars, trim) and routes all three through it:

- `src/input.rs` — device scan / name comparison
- `src/waf_helper.rs` — the device list served to MapperManager
- `src/config.rs` — the `name=` read back from config, so configs already holding a mangled name keep matching after upgrade

MAC (`uniq`) matching already takes precedence when set and is untouched.

Refs #20