### PR TITLE
feat(layout): override us keymap via bind-mount (lean)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rust-based Linux input device event mapper for Kindle e-readers. Maps button p
 - Debouncing to prevent double-triggers
 - Auto-reconnect on device disconnect
 - Optional exclusive device grab
-- Per-keyboard XKB layout, re-applied on every reconnect
+- Non-US keyboard layout via XKB override, with optional Alt+Shift toggle
 
 ## Building
 
@@ -51,7 +51,7 @@ on_disconnect = /path/to/script.sh
 name = Device Name
 uniq = AA:BB:CC:DD:EE:FF   # Bluetooth MAC; matched first when set
 grab = true
-# keyboard_layout = fr     # XKB layout re-applied whenever this keyboard connects
+# keyboard_layout = fr     # XKB layout override (comma list for an Alt+Shift toggle, e.g. us,ru)
 
 [device.gamepad.buttons]
 # button_code = /path/to/script.sh
@@ -76,7 +76,7 @@ Devices are matched by identity, never by `/dev/input/eventX` path (that index i
 unstable across reconnects): the mapper uses the Bluetooth MAC (`uniq`) when set,
 otherwise the device `name`. Set at least one.
 
-Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to remap a Bluetooth keyboard. The mapper re-applies it on every connect, so the layout survives reconnects instead of reverting to US. Leave it unset to keep the system default.
+Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to type correctly on a non-US Bluetooth keyboard. The reader re-pins the `us` core keymap on every focus and `/usr/share/X11/xkb` is read-only, so the mapper bind-mounts a generated `us` symbols file over the system one; every re-pin then resolves to your layout, reverted when the daemon stops. Give a comma list for an Alt+Shift toggle (`us,ru`); it's a system-wide override taken from the first device that sets one. Leave it unset to keep the system default.
 
 Use `log_buttons = true` to discover button codes for your device.
 

--- a/assets/kindle-button-mapper.upstart
+++ b/assets/kindle-button-mapper.upstart
@@ -11,3 +11,8 @@ console none
 script
     exec /mnt/us/kindle-button-mapper/kindle-button-mapper /mnt/us/kindle-button-mapper/config.ini >>/var/log/kindle-button-mapper.log 2>&1
 end script
+
+# SIGTERM skips Drop, so undo the layout override here.
+post-stop script
+    umount /usr/share/X11/xkb/symbols/us 2>/dev/null || true
+end script

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,85 @@
+use log::{info, warn};
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const XKB_DIR: &str = "/usr/share/X11/xkb";
+const US: &str = "/usr/share/X11/xkb/symbols/us";
+const OVERRIDE: &str = "/var/local/kbm-us";
+
+/// Bind-mounts a generated `us` symbols file over the read-only system one, so
+/// the framework's `pc+us` re-pin on focus loads the user's layout.
+pub struct LayoutOverride;
+
+impl LayoutOverride {
+    pub fn new(layout: &str) -> Option<Self> {
+        let groups: Vec<&str> = layout.split(',').map(str::trim).filter(|s| !s.is_empty()).collect();
+        if groups.is_empty() {
+            return None;
+        }
+        if fs::write(OVERRIDE, symbols(&groups)).is_err() {
+            warn!("layout: cannot write {OVERRIDE}");
+            return None;
+        }
+        let _ = run("umount", &[US]);
+        if !run("mount", &["--bind", OVERRIDE, US]) {
+            warn!("layout '{layout}': bind-mount over us failed");
+            return None;
+        }
+        load();
+        info!("layout '{layout}' active");
+        Some(LayoutOverride)
+    }
+}
+
+impl Drop for LayoutOverride {
+    fn drop(&mut self) {
+        if run("umount", &[US]) {
+            load();
+        }
+    }
+}
+
+fn symbols(groups: &[&str]) -> String {
+    let mut s = String::from("default partial alphanumeric_keys modifier_keys\nxkb_symbols \"basic\" {\n");
+    for (i, g) in groups.iter().enumerate() {
+        // `us` is the file we shadow, so include its `latin` base instead of recursing.
+        let name = if *g == "us" { "latin" } else { g };
+        if i == 0 {
+            s.push_str(&format!("    include \"{name}\"\n"));
+        } else {
+            s.push_str(&format!("    include \"{name}:{}\"\n", i + 1));
+        }
+    }
+    if groups.len() > 1 {
+        s.push_str("    include \"group(alt_shift_toggle)\"\n");
+    }
+    s.push_str("};\n");
+    s
+}
+
+fn load() {
+    let keymap = "xkb_keymap { xkb_keycodes { include \"evdev+aliases(qwerty)\" }; \
+                  xkb_types { include \"complete\" }; xkb_compat { include \"complete\" }; \
+                  xkb_symbols { include \"pc+us\" }; xkb_geometry { include \"pc(pc105)\" }; };\n";
+    if let Ok(mut child) = Command::new("xkbcomp")
+        .args([&format!("-I{XKB_DIR}"), "-", ":0"])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(keymap.as_bytes());
+        }
+        let _ = child.wait();
+    }
+}
+
+fn run(cmd: &str, args: &[&str]) -> bool {
+    Command::new(cmd)
+        .args(args)
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod input;
+mod layout;
 mod mapper;
 mod pause;
 mod vkeyboard;
@@ -8,15 +9,15 @@ mod waf_helper;
 use config::Config;
 use evdev::InputEventKind;
 use input::InputHandler;
+use layout::LayoutOverride;
 use log::{error, info, warn};
 use mapper::Mapper;
 use nix::poll::{poll, PollFd, PollFlags};
 use nix::sys::signal::{signal, SigHandler, Signal};
 use std::env;
-use std::io::Write;
 use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
-use std::process::{self, Command, Stdio};
+use std::process::{self, Command};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -91,6 +92,14 @@ fn main() {
     // scripts/key.sh can inject events into it.
     let _vkeyboard = vkeyboard::try_init();
 
+    // System-wide XKB override, set up once. First device that names a layout wins.
+    let _layout = config
+        .devices
+        .iter()
+        .find_map(|d| d.keyboard_layout.as_deref())
+        .filter(|l| !l.is_empty())
+        .and_then(LayoutOverride::new);
+
     let mut handles = Vec::new();
     let settings = WorkerSettings {
         debounce_ms: config.debounce_ms,
@@ -150,10 +159,6 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
                 if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
-                }
-                if let Some(ref layout) = cfg.keyboard_layout {
-                    info!("[{}] applying keyboard layout '{}'", cfg.id, layout);
-                    apply_keyboard_layout(layout);
                 }
                 if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab, settings.keep_awake) {
                     error!("[{}] event loop error: {}", cfg.id, e);
@@ -291,31 +296,3 @@ fn execute_script(script: &str) {
     }
 }
 
-const XKB_DISPLAY: &str = ":0";
-
-fn apply_keyboard_layout(layout: &str) {
-    let keymap = format!(
-        "xkb_keymap {{\n\
-         \x20 xkb_keycodes {{ include \"evdev+aliases(qwerty)\" }};\n\
-         \x20 xkb_types {{ include \"complete\" }};\n\
-         \x20 xkb_compat {{ include \"complete\" }};\n\
-         \x20 xkb_symbols {{ include \"pc+{layout}\" }};\n\
-         \x20 xkb_geometry {{ include \"pc(pc105)\" }};\n\
-         }};\n"
-    );
-    let mut child = match Command::new("xkbcomp")
-        .args(["-I/usr/share/X11/xkb", "-", XKB_DISPLAY])
-        .stdin(Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            error!("xkbcomp failed to start: {}", e);
-            return;
-        }
-    };
-    if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(keymap.as_bytes());
-    }
-    let _ = child.wait();
-}


### PR DESCRIPTION
Lean reimplementation of the reverted #15.

## What

Set a non-US keyboard layout by bind-mounting a generated `us` symbols file over the read-only system one, so the framework's `pc+us` re-pin on focus loads the user's layout instead. `keyboard_layout` takes a comma list for an Alt+Shift toggle (`us,ru`). Set up once system-wide (first device that names a layout wins), unmounted on stop via `Drop` plus an upstart `post-stop` (SIGTERM skips Drop).

Replaces the one-shot `apply_keyboard_layout`, which raced the framework re-pin and reverted to `us`.

## Why this shape

`/usr/share/X11/xkb` is a read-only squashfs, so `us` can't be edited in place; and setting the layout on the running server doesn't stick because the framework re-pins `pc+us` on every input focus. Overriding what `us` compiles to is the only thing that survives the re-pin. The `us` group pulls `latin` to avoid recursing into the shadowed `us`.

## vs #15

Same validated mechanism, without the burst-reassert machinery, the vkeyboard passthrough coupling, or the comment essays. `src/layout.rs` is one small module; `main.rs` loses more than it gains.

## Testing

`cargo build` + `clippy` clean. The bind-mount + `xkbcomp` path is identical to what was verified on-device (MTK Bellatrix + i.MX6SLL, and a Scribe by a tester) on #15: `ru` types Cyrillic, `us,ru` gives the Alt+Shift toggle, `umount` restores stock `us`. Happy to re-run on-device before merge.

## Known nits (follow-ups, not blockers)
- 3+ layouts toggle out of order (`us,ru,kz` cycles us->kz->ru; `kz` includes `ru`).
- Cosmetic extra symbols on modifiers in native/XKB apps (the `latin` base's AltGr levels), not in KOReader/Abiword.

Refs #12.