### PR TITLE
Add native Kindle reader actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Rust-based Linux input device event mapper for Kindle e-readers. Maps button p
 ## Features
 
 - Map buttons to shell scripts
+- Page turns and reader controls for both the native Kindle reader and KOReader
 - Long press support with separate actions
 - Auto-repeat when buttons are held
 - Debouncing to prevent double-triggers
@@ -80,6 +81,20 @@ Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) t
 
 Use `log_buttons = true` to discover button codes for your device.
 
+### Reader actions
+
+Two helper scripts ship with the mapper, so a binding can drive either reader:
+
+| | `scripts/kindle.sh` (native reader) | `scripts/koreader.sh` (KOReader) |
+|---|---|---|
+| How it talks to the reader | virtual keyboard + `lipc` | HTTP Inspector on `localhost:8080` |
+| Setup needed | none | HTTP Inspector auto-start |
+| Actions | `next_page`, `prev_page`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
+
+The native reader takes `KEY_DOWN` as next page and `KEY_UP` as previous page, so
+`kindle.sh` turns pages through the daemon's own uinput keyboard — no touch
+injection and no coordinates to get wrong. Everything else goes over `lipc`.
+
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.
 
 ## On-device UI (MapperManager WAF)
@@ -99,7 +114,7 @@ ssh kindle "sh /mnt/us/kindle-button-mapper/illusion/install-waf-app.sh"   # fir
 ```
 
 The app has three tabs:
-- **Bindings** — list of current button / D-pad / trigger mappings per device. Tap *+ Add* to capture a button and pick an action. Each binding can map to a KOReader command, a keyboard key, or a custom shell command.
+- **Bindings** — list of current button / D-pad / trigger mappings per device. Tap *+ Add* to capture a button and pick an action. The action picker opens on **Kindle** (native reader) and also offers **KOReader**, a keyboard key, or a custom shell command.
 - **Device** — list of configured devices, each matched by its Bluetooth MAC or name. Add, edit, or remove a device, or tap one seen on `/dev/input` to prefill its name and MAC.
 - **Debug** — live button capture for discovering codes, and a raw `config.ini` editor.
 
@@ -133,6 +148,7 @@ Uninstall: `ssh kindle "sh /mnt/us/kindle-button-mapper/uninstall.sh"` (the scri
 - Jailbroken Kindle (Kindle 5+ / FW 5.x).
 - Linux kernel with evdev (`/dev/input/eventX`) — present on all stock Kindles.
 - An input device the Kindle can see — e.g. a Bluetooth gamepad/remote bridged via [kindle-hid-passthrough](https://github.com/zampierilucas/kindle-hid-passthrough), or any USB OTG HID device.
+- Nothing extra for the native Kindle reader — `scripts/kindle.sh` only needs the daemon running.
 - **KOReader HTTP Inspector** (for KOReader integration): enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. The default mappings in `scripts/koreader.sh` send commands to `localhost:8080`. MapperManager warns you in the KOReader action tab when this auto-start is off.
 
 ## Hardware

--- a/config.ini
+++ b/config.ini
@@ -16,19 +16,21 @@ keep_awake = true
 # grab = false
 # keyboard_layout = fr        # optional XKB layout, re-applied on every connect
 #
+# kindle.sh drives the native Kindle reader, koreader.sh drives KOReader.
+#
 # [device.gamepad.buttons]
-# 304 = /mnt/us/kindle-button-mapper/scripts/koreader.sh next_page
-# 305 = /mnt/us/kindle-button-mapper/scripts/koreader.sh prev_page
+# 304 = /mnt/us/kindle-button-mapper/scripts/kindle.sh next_page
+# 305 = /mnt/us/kindle-button-mapper/scripts/kindle.sh prev_page
 #
 # [device.gamepad.dpad]
-# up = /mnt/us/kindle-button-mapper/scripts/koreader.sh prev_page
-# down = /mnt/us/kindle-button-mapper/scripts/koreader.sh next_page
-# left = /mnt/us/kindle-button-mapper/scripts/koreader.sh rotate
-# right = /mnt/us/kindle-button-mapper/scripts/koreader.sh toggle_status_bar
+# up = /mnt/us/kindle-button-mapper/scripts/kindle.sh prev_page
+# down = /mnt/us/kindle-button-mapper/scripts/kindle.sh next_page
+# left = /mnt/us/kindle-button-mapper/scripts/kindle.sh back
+# right = /mnt/us/kindle-button-mapper/scripts/kindle.sh toolbar
 #
 # [device.gamepad.triggers]
-# lt = /mnt/us/kindle-button-mapper/scripts/koreader.sh font_up 1
-# rt = /mnt/us/kindle-button-mapper/scripts/koreader.sh brightness -10
+# lt = /mnt/us/kindle-button-mapper/scripts/kindle.sh brightness 1
+# rt = /mnt/us/kindle-button-mapper/scripts/kindle.sh brightness -1
 #
 # [device.gamepad.longpress]
-# 304 = /mnt/us/kindle-button-mapper/scripts/koreader.sh menu
+# 304 = /mnt/us/kindle-button-mapper/scripts/kindle.sh home

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -148,7 +148,8 @@
         <div class="dialog dialog-tall">
             <p id="actionTitle">Pick an action</p>
             <div class="tab-bar tab-bar-inline">
-                <button class="action-tab action-tab-active" data-action-tab="koreader">KOReader</button>
+                <button class="action-tab action-tab-active" data-action-tab="kindle">Kindle</button>
+                <button class="action-tab" data-action-tab="koreader">KOReader</button>
                 <button class="action-tab" data-action-tab="keyboard">Keyboard</button>
                 <button class="action-tab" data-action-tab="custom">Custom</button>
             </div>

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -11,13 +11,13 @@ var MapperManager = (function() {
     var MESSAGE_TIMEOUT = 4000;
 
     var messageTimer = null;
-    var actions = [];          // [{id, label}] from /actions
+    var actions = [];          // [{kind, id, label}] from /actions
     var layouts = [];          // [{code, name}] from /layouts
     var devices = [];          // [{path, name, uniq}]
     var ini = null;            // parsed config
     var pendingSlot = null;    // slot object awaiting an action pick
     var captureXhrAbort = null;
-    var actionTab = "koreader"; // which tab is showing in the action picker
+    var actionTab = "kindle";   // which tab is showing in the action picker
     var currentDeviceId = null; // currently selected device on Bindings tab
     var editingDeviceId = null; // device being edited in the detail overlay (null = new)
     var continuousCapture = false; // when true, re-fire capture after each action pick
@@ -414,19 +414,35 @@ var MapperManager = (function() {
 
     function extractAction(script) {
         if (!script) return { kind: "other", id: "" };
-        var m = script.match(/koreader\.sh\s+(.+?)\s*$/);
+        var m = script.match(/kindle\.sh\s+(.+?)\s*$/);
+        if (m) return { kind: "kindle", id: m[1].replace(/^\s+|\s+$/g, "") };
+        m = script.match(/koreader\.sh\s+(.+?)\s*$/);
         if (m) return { kind: "koreader", id: m[1].replace(/^\s+|\s+$/g, "") };
         m = script.match(/key\.sh\s+(.+?)\s*$/);
         if (m) return { kind: "keyboard", id: m[1].replace(/^\s+|\s+$/g, "") };
         return { kind: "other", id: script };
     }
 
+    function actionsForKind(kind) {
+        var out = [];
+        for (var i = 0; i < actions.length; i++) {
+            if (actions[i].kind === kind) out.push(actions[i]);
+        }
+        return out;
+    }
+
     function labelForAction(parsed) {
-        var list = parsed.kind === "keyboard" ? keyboardKeys() : actions;
-        for (var i = 0; i < list.length; i++) {
-            if (list[i].id === parsed.id) {
-                return (parsed.kind === "keyboard" ? "Key: " : "") + list[i].label;
+        if (parsed.kind === "keyboard") {
+            var keys = keyboardKeys();
+            for (var i = 0; i < keys.length; i++) {
+                if (keys[i].id === parsed.id) return "Key: " + keys[i].label;
             }
+            return null;
+        }
+        var list = actionsForKind(parsed.kind);
+        var prefix = parsed.kind === "koreader" ? "KOReader: " : "";
+        for (var j = 0; j < list.length; j++) {
+            if (list[j].id === parsed.id) return prefix + list[j].label;
         }
         return null;
     }
@@ -438,7 +454,10 @@ var MapperManager = (function() {
         if (kind === "custom") {
             return actionId;
         }
-        return "/mnt/us/kindle-button-mapper/scripts/koreader.sh " + actionId;
+        if (kind === "koreader") {
+            return "/mnt/us/kindle-button-mapper/scripts/koreader.sh " + actionId;
+        }
+        return "/mnt/us/kindle-button-mapper/scripts/kindle.sh " + actionId;
     }
 
     // ---- Slot picker (Add) ----
@@ -561,8 +580,9 @@ var MapperManager = (function() {
         var existing = pendingSlot ? getValue(pendingSlot.section, pendingSlot.key) : null;
         var parsed = extractAction(existing);
         actionTab = parsed.kind === "keyboard" ? "keyboard"
+                  : parsed.kind === "koreader" ? "koreader"
                   : parsed.kind === "other" && existing ? "custom"
-                  : "koreader";
+                  : "kindle";
         filteredKeys = keyboardKeys();
         getEl("actionSearch").value = "";
         getEl("actionCustomCmd").value = (parsed.kind === "other" && existing) ? existing : "";
@@ -589,7 +609,7 @@ var MapperManager = (function() {
 
         if (isCustom) return;
 
-        var items = isKbd ? filteredKeys : actions;
+        var items = isKbd ? filteredKeys : actionsForKind(actionTab);
         var html = "";
         for (var j = 0; j < items.length; j++) {
             html += '<div class="action-item" data-id="' + escapeHtml(items[j].id) + '">'

--- a/illusion/MapperManager/style.css
+++ b/illusion/MapperManager/style.css
@@ -475,9 +475,9 @@ html, body {
 
 .action-tab {
     float: left;
-    width: 33.33%;
+    width: 25%;
     padding: 14px 0;
-    font-size: 32px;
+    font-size: 28px;
     font-weight: bold;
     background: #fff;
     color: #000;

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Native Kindle reader control.
+# Usage: kindle.sh <command> [args...]
+#
+# Commands:
+#   next_page         - Turn to next page
+#   prev_page         - Turn to previous page
+#   home              - Go to the home screen
+#   back              - Back / close the current view
+#   toolbar           - Toggle the reader toolbar
+#   brightness <n>    - Adjust frontlight (positive=up, negative=down)
+#   brightness_toggle - Toggle frontlight off/on
+#
+# Page turns go through the daemon's virtual keyboard: the native reader
+# takes KEY_DOWN as next page and KEY_UP as previous page. The rest is lipc.
+
+DIR=$(dirname "$0")
+LOG_PATH="/var/log/kindle-button-mapper.log"
+FL_SAVED="/var/run/kindle-button-mapper-fl"
+
+warn() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  kindle.sh: $1" >> "$LOG_PATH" 2>/dev/null
+}
+
+send_key() {
+    if ! "$DIR/key.sh" "$1" 2>/dev/null; then
+        warn "cannot inject $1; the daemon's virtual keyboard is not running"
+    fi
+}
+
+fl_get() { lipc-get-prop com.lab126.powerd flIntensity 2>/dev/null || echo 0; }
+fl_max() { lipc-get-prop com.lab126.powerd flMaxIntensity 2>/dev/null || echo 24; }
+fl_set() { lipc-set-prop com.lab126.powerd flIntensity "$1" 2>/dev/null; }
+
+case "$1" in
+    next_page)
+        send_key KEY_DOWN
+        ;;
+    prev_page)
+        send_key KEY_UP
+        ;;
+    home)
+        send_key KEY_HOME
+        ;;
+    back)
+        lipc-set-prop com.lab126.appmgrd kppBackButtonPress 1 2>/dev/null \
+            || warn "back: appmgrd not reachable"
+        ;;
+    toolbar)
+        state=$(lipc-get-prop com.lab126.winmgr chromeState 2>/dev/null || echo 0)
+        if [ "$state" = "0" ]; then
+            lipc-set-prop com.lab126.winmgr chromeState 1 2>/dev/null
+        else
+            lipc-set-prop com.lab126.winmgr chromeState 0 2>/dev/null
+        fi
+        ;;
+    brightness)
+        step="${2:-1}"
+        max=$(fl_max)
+        new=$(( $(fl_get) + step ))
+        [ "$new" -lt 0 ] && new=0
+        [ "$new" -gt "$max" ] && new="$max"
+        fl_set "$new"
+        ;;
+    brightness_toggle)
+        cur=$(fl_get)
+        if [ "$cur" -gt 0 ]; then
+            echo "$cur" > "$FL_SAVED" 2>/dev/null
+            fl_set 0
+        else
+            prev=$(cat "$FL_SAVED" 2>/dev/null)
+            case "$prev" in
+                ""|0|*[!0-9]*) prev=$(( $(fl_max) / 2 )) ;;
+            esac
+            fl_set "$prev"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 <command> [args...]"
+        echo "Commands: next_page, prev_page, home, back, toolbar,"
+        echo "          brightness <n>, brightness_toggle"
+        exit 1
+        ;;
+esac

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -12,20 +12,32 @@ const INPUT_DIR: &str = "/dev/input";
 const INITCTL: &str = "/sbin/initctl";
 const SERVICE: &str = "kindle-button-mapper";
 
-const ACTIONS: &[(&str, &str)] = &[
-    ("next_page", "Next page"),
-    ("prev_page", "Previous page"),
-    ("brightness 1", "Brightness +1"),
-    ("brightness -1", "Brightness -1"),
-    ("brightness 10", "Brightness +10"),
-    ("brightness -10", "Brightness -10"),
-    ("brightness_toggle", "Toggle frontlight"),
-    ("night_mode", "Toggle night mode"),
-    ("font_up 1", "Font +1"),
-    ("font_down 1", "Font -1"),
-    ("menu", "Show menu"),
-    ("toggle_status_bar", "Toggle status bar"),
-    ("rotate", "Rotate screen"),
+// (kind, id, label) — kind matches the tab in the WAF action picker and
+// selects the script the binding is written against.
+const ACTIONS: &[(&str, &str, &str)] = &[
+    ("kindle", "next_page", "Next page"),
+    ("kindle", "prev_page", "Previous page"),
+    ("kindle", "home", "Home screen"),
+    ("kindle", "back", "Back"),
+    ("kindle", "toolbar", "Toggle toolbar"),
+    ("kindle", "brightness 1", "Brightness +1"),
+    ("kindle", "brightness -1", "Brightness -1"),
+    ("kindle", "brightness 5", "Brightness +5"),
+    ("kindle", "brightness -5", "Brightness -5"),
+    ("kindle", "brightness_toggle", "Toggle frontlight"),
+    ("koreader", "next_page", "Next page"),
+    ("koreader", "prev_page", "Previous page"),
+    ("koreader", "brightness 1", "Brightness +1"),
+    ("koreader", "brightness -1", "Brightness -1"),
+    ("koreader", "brightness 10", "Brightness +10"),
+    ("koreader", "brightness -10", "Brightness -10"),
+    ("koreader", "brightness_toggle", "Toggle frontlight"),
+    ("koreader", "night_mode", "Toggle night mode"),
+    ("koreader", "font_up 1", "Font +1"),
+    ("koreader", "font_down 1", "Font -1"),
+    ("koreader", "menu", "Show menu"),
+    ("koreader", "toggle_status_bar", "Toggle status bar"),
+    ("koreader", "rotate", "Rotate screen"),
 ];
 
 static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
@@ -261,7 +273,14 @@ fn devices_json() -> String {
 fn actions_json() -> String {
     let items: Vec<String> = ACTIONS
         .iter()
-        .map(|(id, label)| format!("{{\"id\":\"{}\",\"label\":\"{}\"}}", esc(id), esc(label)))
+        .map(|(kind, id, label)| {
+            format!(
+                "{{\"kind\":\"{}\",\"id\":\"{}\",\"label\":\"{}\"}}",
+                esc(kind),
+                esc(id),
+                esc(label)
+            )
+        })
         .collect();
     format!("{{\"ok\":true,\"actions\":[{}]}}", items.join(","))
 }


### PR DESCRIPTION
Right now the mapper can only drive KOReader. The native reader has had no
supported path since the old recorded-touch-blob scripts got dropped in 2f4cfc4,
and those were pretty bad anyway, a base64 evdev dump replayed into a hardcoded
/dev/input/event1 with hardcoded coordinates baked in.

Turns out the native reader takes KEY_DOWN as next page and KEY_UP as previous
page. So page turns can just go through the uinput keyboard the daemon already
creates. No touch injection, no coordinates to get wrong, nothing model specific.

I did look at winmgr's `fakeTap` first and it's a dead end. `lab126_eat_tap_mode.lua`
gates it behind ASR mode or `eatTapMode`, and `eatTapMode` swallows every real
touch while it's on, so you'd be trading working fingers for working buttons.

New `scripts/kindle.sh` wraps the keyboard trick plus lipc for everything else.

```
next_page / prev_page / home   KEY_DOWN / KEY_UP / KEY_HOME
back                            com.lab126.appmgrd kppBackButtonPress
toolbar                         com.lab126.winmgr chromeState
brightness <n> / _toggle        com.lab126.powerd flIntensity, clamped to flMaxIntensity
```

The WAF action picker gets a Kindle tab, now the default, with KOReader moved to
second. `/actions` tags every entry with its kind so the picker can split them and
existing koreader.sh bindings still resolve to their own tab with a `KOReader:` prefix.

Tested on a Basic 5 (MT8110, FW 5.16.2.1.1). Swept about 40 keycodes to find the
working ones, PAGEDOWN/RIGHT/SPACE/F-keys/media keys all do nothing. Confirmed page
turns by location counter (Loc 1 to Loc 18 and back), and round-tripped a binding
through the real picker on device.

Fixes #23