### PR TITLE
Fix native reader actions on stock firmware

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -48,7 +48,7 @@ jobs:
           cp target/armv7-unknown-linux-musleabihf/release/kindle-button-mapper output/
           cp install.sh uninstall.sh config.ini output/
           cp assets/kindle-button-mapper.upstart output/assets/
-          cp scripts/koreader.sh scripts/key.sh output/scripts/
+          cp scripts/*.sh output/scripts/
           cp illusion/MapperManager.sh illusion/install-waf-app.sh output/illusion/
           cp illusion/MapperManager/config.xml illusion/MapperManager/index.html \
              illusion/MapperManager/style.css illusion/MapperManager/script.js \
@@ -81,8 +81,7 @@ jobs:
             uninstall.sh \
             config.ini \
             assets/kindle-button-mapper.upstart \
-            scripts/koreader.sh \
-            scripts/key.sh \
+            $(ls scripts/*.sh) \
             illusion/MapperManager.sh \
             illusion/install-waf-app.sh \
             illusion/MapperManager/config.xml \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 evdev = "0.12"
 configparser = "3"
-nix = { version = "0.29", features = ["inotify", "signal", "poll", "ioctl"] }
+nix = { version = "0.29", features = ["inotify", "signal", "poll", "ioctl", "fs"] }
 log = "0.4"
 env_logger = "0.11"
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ if you read in both: it checks whether KOReader is answering on its HTTP
 Inspector port and routes there, falling back to the native reader. One binding
 per button covers both readers.
 
-The native reader takes `KEY_DOWN` as next page and `KEY_UP` as previous page, so
-`kindle.sh` turns pages through the daemon's own uinput keyboard — no touch
-injection and no coordinates to get wrong. The daemon holds that uinput device
-open and reads key names off `/var/run/kindle-button-mapper-key.fifo`, which is
-how `scripts/key.sh` injects without any external tool. Everything else goes
-over `lipc`.
+Page turns are injected, not tapped, so there are no coordinates to get wrong.
+The daemon reads requests off `/var/run/kindle-button-mapper-key.fifo`, which is
+how `scripts/key.sh` works without any external tool, and it picks the device.
+On a model with physical page buttons the framework only turns pages for that
+node, so the daemon writes `KEY_PAGEDOWN`/`KEY_PAGEUP` straight into it and the
+reader sees a normal button press. Everywhere else the native reader takes
+`KEY_DOWN` as next page and `KEY_UP` as previous page on the virtual keyboard.
+Everything else goes over `lipc`.
 
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.
 

--- a/README.md
+++ b/README.md
@@ -83,17 +83,25 @@ Use `log_buttons = true` to discover button codes for your device.
 
 ### Reader actions
 
-Two helper scripts ship with the mapper, so a binding can drive either reader:
+Three helper scripts ship with the mapper, so a binding can drive either reader:
 
-| | `scripts/kindle.sh` (native reader) | `scripts/koreader.sh` (KOReader) |
-|---|---|---|
-| How it talks to the reader | virtual keyboard + `lipc` | HTTP Inspector on `localhost:8080` |
-| Setup needed | none | HTTP Inspector auto-start |
-| Actions | `next_page`, `prev_page`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
+| | `scripts/auto.sh` (whatever is on screen) | `scripts/kindle.sh` (native reader) | `scripts/koreader.sh` (KOReader) |
+|---|---|---|---|
+| How it talks to the reader | picks one of the two below | virtual keyboard + `lipc` | HTTP Inspector on `localhost:8080` |
+| Setup needed | none | none | HTTP Inspector auto-start |
+| Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
+
+`auto.sh` is what the Auto tab in MapperManager writes, and it is the one to use
+if you read in both: it checks whether KOReader is answering on its HTTP
+Inspector port and routes there, falling back to the native reader. One binding
+per button covers both readers.
 
 The native reader takes `KEY_DOWN` as next page and `KEY_UP` as previous page, so
 `kindle.sh` turns pages through the daemon's own uinput keyboard — no touch
-injection and no coordinates to get wrong. Everything else goes over `lipc`.
+injection and no coordinates to get wrong. The daemon holds that uinput device
+open and reads key names off `/var/run/kindle-button-mapper-key.fifo`, which is
+how `scripts/key.sh` injects without any external tool. Everything else goes
+over `lipc`.
 
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.
 
@@ -148,7 +156,7 @@ Uninstall: `ssh kindle "sh /mnt/us/kindle-button-mapper/uninstall.sh"` (the scri
 - Jailbroken Kindle (Kindle 5+ / FW 5.x).
 - Linux kernel with evdev (`/dev/input/eventX`) — present on all stock Kindles.
 - An input device the Kindle can see — e.g. a Bluetooth gamepad/remote bridged via [kindle-hid-passthrough](https://github.com/zampierilucas/kindle-hid-passthrough), or any USB OTG HID device.
-- Nothing extra for the native Kindle reader — `scripts/kindle.sh` only needs the daemon running.
+- Nothing extra for the native Kindle reader — `scripts/kindle.sh` and `scripts/auto.sh` only need the daemon running.
 - **KOReader HTTP Inspector** (for KOReader integration): enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. The default mappings in `scripts/koreader.sh` send commands to `localhost:8080`. MapperManager warns you in the KOReader action tab when this auto-start is off.
 
 ## Hardware

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -148,7 +148,8 @@
         <div class="dialog dialog-tall">
             <p id="actionTitle">Pick an action</p>
             <div class="tab-bar tab-bar-inline">
-                <button class="action-tab action-tab-active" data-action-tab="kindle">Kindle</button>
+                <button class="action-tab action-tab-active" data-action-tab="auto">Auto</button>
+                <button class="action-tab" data-action-tab="kindle">Kindle</button>
                 <button class="action-tab" data-action-tab="koreader">KOReader</button>
                 <button class="action-tab" data-action-tab="keyboard">Keyboard</button>
                 <button class="action-tab" data-action-tab="custom">Custom</button>

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -17,7 +17,7 @@ var MapperManager = (function() {
     var ini = null;            // parsed config
     var pendingSlot = null;    // slot object awaiting an action pick
     var captureXhrAbort = null;
-    var actionTab = "kindle";   // which tab is showing in the action picker
+    var actionTab = "auto";     // which tab is showing in the action picker
     var currentDeviceId = null; // currently selected device on Bindings tab
     var editingDeviceId = null; // device being edited in the detail overlay (null = new)
     var continuousCapture = false; // when true, re-fire capture after each action pick
@@ -414,7 +414,9 @@ var MapperManager = (function() {
 
     function extractAction(script) {
         if (!script) return { kind: "other", id: "" };
-        var m = script.match(/kindle\.sh\s+(.+?)\s*$/);
+        var m = script.match(/auto\.sh\s+(.+?)\s*$/);
+        if (m) return { kind: "auto", id: m[1].replace(/^\s+|\s+$/g, "") };
+        m = script.match(/kindle\.sh\s+(.+?)\s*$/);
         if (m) return { kind: "kindle", id: m[1].replace(/^\s+|\s+$/g, "") };
         m = script.match(/koreader\.sh\s+(.+?)\s*$/);
         if (m) return { kind: "koreader", id: m[1].replace(/^\s+|\s+$/g, "") };
@@ -440,7 +442,8 @@ var MapperManager = (function() {
             return null;
         }
         var list = actionsForKind(parsed.kind);
-        var prefix = parsed.kind === "koreader" ? "KOReader: " : "";
+        var prefix = parsed.kind === "koreader" ? "KOReader: "
+                   : parsed.kind === "kindle" ? "Kindle: " : "";
         for (var j = 0; j < list.length; j++) {
             if (list[j].id === parsed.id) return prefix + list[j].label;
         }
@@ -457,7 +460,10 @@ var MapperManager = (function() {
         if (kind === "koreader") {
             return "/mnt/us/kindle-button-mapper/scripts/koreader.sh " + actionId;
         }
-        return "/mnt/us/kindle-button-mapper/scripts/kindle.sh " + actionId;
+        if (kind === "kindle") {
+            return "/mnt/us/kindle-button-mapper/scripts/kindle.sh " + actionId;
+        }
+        return "/mnt/us/kindle-button-mapper/scripts/auto.sh " + actionId;
     }
 
     // ---- Slot picker (Add) ----
@@ -581,8 +587,9 @@ var MapperManager = (function() {
         var parsed = extractAction(existing);
         actionTab = parsed.kind === "keyboard" ? "keyboard"
                   : parsed.kind === "koreader" ? "koreader"
+                  : parsed.kind === "kindle" ? "kindle"
                   : parsed.kind === "other" && existing ? "custom"
-                  : "kindle";
+                  : "auto";
         filteredKeys = keyboardKeys();
         getEl("actionSearch").value = "";
         getEl("actionCustomCmd").value = (parsed.kind === "other" && existing) ? existing : "";
@@ -605,6 +612,7 @@ var MapperManager = (function() {
         getEl("actionList").style.display = isCustom ? "none" : "block";
 
         if (actionTab === "koreader") refreshKoreaderStatus();
+        else if (actionTab === "auto") showAutoNote();
         else getEl("koreaderStatus").className = "koreader-status hidden";
 
         if (isCustom) return;
@@ -618,6 +626,13 @@ var MapperManager = (function() {
         var list = getEl("actionList");
         list.innerHTML = html;
         list.scrollTop = 0;
+    }
+
+    function showAutoNote() {
+        var el = getEl("koreaderStatus");
+        el.className = "koreader-status";
+        el.innerHTML = "Goes to KOReader when it is running with the HTTP Inspector on, "
+            + "and to the native reader otherwise \u2014 one binding covers both.";
     }
 
     function refreshKoreaderStatus() {

--- a/illusion/MapperManager/style.css
+++ b/illusion/MapperManager/style.css
@@ -475,9 +475,9 @@ html, body {
 
 .action-tab {
     float: left;
-    width: 25%;
+    width: 20%;
     padding: 14px 0;
-    font-size: 28px;
+    font-size: 24px;
     font-weight: bold;
     background: #fff;
     color: #000;

--- a/scripts/auto.sh
+++ b/scripts/auto.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Reader control that follows whatever is on screen.
+# Usage: auto.sh <command> [args...]
+#
+# Commands:
+#   next_page         - Turn to next page
+#   prev_page         - Turn to previous page
+#   brightness <n>    - Adjust frontlight (positive=up, negative=down)
+#   brightness_toggle - Toggle frontlight off/on
+#   menu              - KOReader menu, native toolbar
+#
+# KOReader answers on its HTTP Inspector port when it is up, so a reachable
+# port means it is the reader in front of you. Everything else, including the
+# native-only commands (home, back, toolbar), goes to kindle.sh.
+
+DIR=$(dirname "$0")
+KOREADER_PROBE="http://localhost:8080/"
+
+koreader_up() {
+    curl -s --connect-timeout 1 -o /dev/null "$KOREADER_PROBE" 2>/dev/null
+}
+
+CMD="$1"
+case "$CMD" in
+    next_page|prev_page|brightness|brightness_toggle|night_mode|font_up|font_down|toggle_status_bar|rotate)
+        koreader_up && exec "$DIR/koreader.sh" "$@"
+        ;;
+    menu)
+        if koreader_up; then
+            exec "$DIR/koreader.sh" menu
+        fi
+        exec "$DIR/kindle.sh" toolbar
+        ;;
+    "")
+        echo "Usage: $0 <command> [args...]"
+        echo "Commands: next_page, prev_page, brightness <n>, brightness_toggle, menu"
+        exit 1
+        ;;
+esac
+
+exec "$DIR/kindle.sh" "$@"

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -1,21 +1,31 @@
 #!/bin/sh
-# Inject a keyboard event into the daemon's virtual uinput keyboard.
-# Usage: key.sh KEY_NAME
+# Ask the daemon to inject an input event.
+# Usage: key.sh KEY_NAME | page_next | page_prev
+#
+# A key name goes into the daemon's virtual uinput keyboard. page_next and
+# page_prev let the daemon pick the device, since Kindles with physical page
+# buttons only turn pages for those.
 
 KEY="$1"
-[ -z "$KEY" ] && { echo "Usage: $0 KEY_NAME" >&2; exit 1; }
+[ -z "$KEY" ] && { echo "Usage: $0 KEY_NAME|page_next|page_prev" >&2; exit 1; }
 
 FIFO="/var/run/kindle-button-mapper-key.fifo"
 FIFO_OWNER="/var/run/kindle-button-mapper-key-owner"
 
-# The daemon owns the uinput fd, so it does the injecting: writing the key name
+# The daemon owns the uinput fd, so it does the injecting. Writing the request
 # to its FIFO works on stock firmware, which has no evemu-event. The pid check
 # keeps a FIFO left behind by a crashed daemon from blocking this write.
 if [ -p "$FIFO" ] && [ -r "$FIFO_OWNER" ] && [ -d "/proc/$(cat "$FIFO_OWNER")" ]; then
     printf '%s\n' "$KEY" > "$FIFO" && exit 0
 fi
 
-# Fallback: an older daemon publishes the event node but no FIFO.
+# Fallback: an older daemon publishes the event node but no FIFO. Page turns
+# only exist as a daemon request, so map them back to keys here.
+case "$KEY" in
+    page_next) KEY=KEY_DOWN ;;
+    page_prev) KEY=KEY_UP ;;
+esac
+
 DEV="$KEY_TARGET_DEV"
 [ -z "$DEV" ] && [ -r /var/run/kindle-button-mapper-key-target ] && DEV=$(cat /var/run/kindle-button-mapper-key-target)
 [ -z "$DEV" ] && [ -r /etc/kindle-button-mapper-key-target ] && DEV=$(cat /etc/kindle-button-mapper-key-target)

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -5,12 +5,28 @@
 KEY="$1"
 [ -z "$KEY" ] && { echo "Usage: $0 KEY_NAME" >&2; exit 1; }
 
+FIFO="/var/run/kindle-button-mapper-key.fifo"
+FIFO_OWNER="/var/run/kindle-button-mapper-key-owner"
+
+# The daemon owns the uinput fd, so it does the injecting: writing the key name
+# to its FIFO works on stock firmware, which has no evemu-event. The pid check
+# keeps a FIFO left behind by a crashed daemon from blocking this write.
+if [ -p "$FIFO" ] && [ -r "$FIFO_OWNER" ] && [ -d "/proc/$(cat "$FIFO_OWNER")" ]; then
+    printf '%s\n' "$KEY" > "$FIFO" && exit 0
+fi
+
+# Fallback: an older daemon publishes the event node but no FIFO.
 DEV="$KEY_TARGET_DEV"
 [ -z "$DEV" ] && [ -r /var/run/kindle-button-mapper-key-target ] && DEV=$(cat /var/run/kindle-button-mapper-key-target)
 [ -z "$DEV" ] && [ -r /etc/kindle-button-mapper-key-target ] && DEV=$(cat /etc/kindle-button-mapper-key-target)
 
 if [ -z "$DEV" ] || [ ! -e "$DEV" ]; then
     echo "key.sh: virtual keyboard not running. Restart the kindle-button-mapper daemon." >&2
+    exit 1
+fi
+
+if ! command -v evemu-event >/dev/null 2>&1; then
+    echo "key.sh: daemon is too old for FIFO injection and evemu-event is not installed. Update kindle-button-mapper." >&2
     exit 1
 fi
 

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -23,9 +23,7 @@ warn() {
 }
 
 send_key() {
-    if ! "$DIR/key.sh" "$1" 2>/dev/null; then
-        warn "cannot inject $1; the daemon's virtual keyboard is not running"
-    fi
+    err=$("$DIR/key.sh" "$1" 2>&1) || warn "cannot inject $1: ${err:-unknown error}"
 }
 
 fl_get() { lipc-get-prop com.lab126.powerd flIntensity 2>/dev/null || echo 0; }

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -11,8 +11,9 @@
 #   brightness <n>    - Adjust frontlight (positive=up, negative=down)
 #   brightness_toggle - Toggle frontlight off/on
 #
-# Page turns go through the daemon's virtual keyboard: the native reader
-# takes KEY_DOWN as next page and KEY_UP as previous page. The rest is lipc.
+# Page turns are handed to the daemon, which injects into the physical page
+# buttons on models that have them and falls back to KEY_DOWN/KEY_UP on its
+# virtual keyboard everywhere else. The rest is lipc.
 
 DIR=$(dirname "$0")
 LOG_PATH="/var/log/kindle-button-mapper.log"
@@ -32,10 +33,10 @@ fl_set() { lipc-set-prop com.lab126.powerd flIntensity "$1" 2>/dev/null; }
 
 case "$1" in
     next_page)
-        send_key KEY_DOWN
+        send_key page_next
         ;;
     prev_page)
-        send_key KEY_UP
+        send_key page_prev
         ;;
     home)
         send_key KEY_HOME

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,7 +236,7 @@ fn fill_trigger_map(
     }
 }
 
-fn parse_key(s: &str) -> Option<Key> {
+pub fn parse_key(s: &str) -> Option<Key> {
     // Try parsing as decimal
     if let Ok(code) = s.parse::<u16>() {
         return Some(Key::new(code));

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,10 +87,11 @@ fn main() {
         signal(Signal::SIGTERM, SigHandler::Handler(handle_signal)).ok();
     }
 
-    // Virtual keyboard via uinput — kept alive for the daemon's lifetime.
-    // The path is written to /var/run/kindle-button-mapper-key-target so
-    // scripts/key.sh can inject events into it.
-    let _vkeyboard = vkeyboard::try_init();
+    // Virtual keyboard via uinput — kept alive for the daemon's lifetime by the
+    // FIFO thread, which injects the keys scripts/key.sh asks for.
+    if let Some(dev) = vkeyboard::try_init() {
+        vkeyboard::serve(dev);
+    }
 
     // System-wide XKB override, set up once. First device that names a layout wins.
     let _layout = config

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -221,17 +221,26 @@ fn page_button_node() -> Option<PathBuf> {
                 .and_then(|n| n.to_str())
                 .is_some_and(|n| n.starts_with("event"))
         })
-        .filter(|p| {
-            evdev::Device::open(p).is_ok_and(|d| {
-                d.name() != Some(DEV_NAME_STR)
-                    && d.supported_keys().is_some_and(|k| {
-                        k.contains(evdev::Key::KEY_PAGEUP) && k.contains(evdev::Key::KEY_PAGEDOWN)
-                    })
-            })
-        })
+        .filter(|p| evdev::Device::open(p).is_ok_and(is_page_buttons))
         .collect();
     found.sort();
     found.into_iter().next()
+}
+
+fn is_page_buttons(dev: evdev::Device) -> bool {
+    if dev.name() == Some(DEV_NAME_STR) {
+        return false;
+    }
+    // Built into the device, so a paired keyboard or gamepad that happens to
+    // carry page keys is never mistaken for the reader's own buttons.
+    if dev.input_id().bus_type() != evdev::BusType::BUS_HOST {
+        return false;
+    }
+    dev.supported_keys().is_some_and(|k| {
+        k.contains(evdev::Key::KEY_PAGEUP)
+            && k.contains(evdev::Key::KEY_PAGEDOWN)
+            && !k.contains(evdev::Key::KEY_A)
+    })
 }
 
 fn tap(dev: &mut File, code: u16) -> io::Result<()> {

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -17,10 +17,15 @@ const FIFO_OWNER: &str = "/var/run/kindle-button-mapper-key-owner";
 const SYSFS_INPUT: &str = "/sys/devices/virtual/input";
 const DEV_INPUT: &str = "/dev/input";
 const DEV_NAME: &[u8] = b"kindle-button-mapper";
+const DEV_NAME_STR: &str = "kindle-button-mapper";
 
 const UINPUT_MAX_NAME_SIZE: usize = 80;
 const ABS_CNT: usize = 64;
 const EV_KEY: u16 = 0x01;
+const KEY_UP: u16 = 103;
+const KEY_PAGEUP: u16 = 104;
+const KEY_DOWN: u16 = 108;
+const KEY_PAGEDOWN: u16 = 109;
 const EV_SYN: u16 = 0x00;
 const SYN_REPORT: u16 = 0x00;
 
@@ -113,6 +118,7 @@ pub fn serve(dev: File) {
 }
 
 fn fifo_loop(mut dev: File) {
+    let mut pager = Pager::find();
     loop {
         // Read/write so a writer closing does not end the loop, and so key.sh
         // never blocks on open while the daemon is alive.
@@ -125,7 +131,7 @@ fn fifo_loop(mut dev: File) {
         };
         for line in BufReader::new(fifo).lines() {
             match line {
-                Ok(l) => handle_request(&mut dev, l.trim()),
+                Ok(l) => handle_request(&mut dev, &mut pager, l.trim()),
                 Err(e) => {
                     warn!("{} read failed: {}", FIFO_PATH, e);
                     break;
@@ -135,18 +141,97 @@ fn fifo_loop(mut dev: File) {
     }
 }
 
-fn handle_request(dev: &mut File, line: &str) {
-    if line.is_empty() {
-        return;
+fn handle_request(dev: &mut File, pager: &mut Pager, line: &str) {
+    match line {
+        "" => (),
+        "page_next" => pager.turn(dev, KEY_PAGEDOWN, KEY_DOWN),
+        "page_prev" => pager.turn(dev, KEY_PAGEUP, KEY_UP),
+        _ => match crate::config::parse_key(line) {
+            Some(key) => {
+                if let Err(e) = tap(dev, key.code()) {
+                    warn!("Injecting {} failed: {}", line, e);
+                }
+            }
+            None => warn!("Key FIFO: unknown key {:?}", line),
+        },
     }
-    match crate::config::parse_key(line) {
-        Some(key) => {
-            if let Err(e) = tap(dev, key.code()) {
-                warn!("Injecting {} failed: {}", line, e);
+}
+
+/// The device the reader takes page turns from.
+///
+/// Kindles with physical page buttons carry them on their own node, and the
+/// framework only turns pages for that node, ignoring page keys from any
+/// keyboard. Writing to an evdev node injects into the device itself, so a
+/// page turn goes in as if the button had been pressed. Models without the
+/// buttons take KEY_DOWN/KEY_UP on the virtual keyboard instead.
+enum Pager {
+    Buttons { path: PathBuf, node: Option<File> },
+    VirtualKeyboard,
+}
+
+impl Pager {
+    fn find() -> Self {
+        match page_button_node() {
+            Some(path) => {
+                info!("Page turns go to the page buttons at {}", path.display());
+                Pager::Buttons { path, node: None }
+            }
+            None => {
+                info!("No page buttons found, page turns go to the virtual keyboard");
+                Pager::VirtualKeyboard
             }
         }
-        None => warn!("Key FIFO: unknown key {:?}", line),
     }
+
+    fn turn(&mut self, vkbd: &mut File, button_code: u16, kbd_code: u16) {
+        match self {
+            Pager::Buttons { path, node } => {
+                if node.is_none() {
+                    match OpenOptions::new().write(true).open(&path) {
+                        Ok(f) => *node = Some(f),
+                        Err(e) => {
+                            warn!("Cannot open {}: {}", path.display(), e);
+                            return;
+                        }
+                    }
+                }
+                let f = node.as_mut().expect("opened above");
+                if let Err(e) = tap(f, button_code) {
+                    warn!("Page turn on {} failed: {}", path.display(), e);
+                    // Reopen next time, the node may have gone away.
+                    *node = None;
+                }
+            }
+            Pager::VirtualKeyboard => {
+                if let Err(e) = tap(vkbd, kbd_code) {
+                    warn!("Page turn failed: {}", e);
+                }
+            }
+        }
+    }
+}
+
+fn page_button_node() -> Option<PathBuf> {
+    let mut found: Vec<PathBuf> = fs::read_dir(DEV_INPUT)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("event"))
+        })
+        .filter(|p| {
+            evdev::Device::open(p).is_ok_and(|d| {
+                d.name() != Some(DEV_NAME_STR)
+                    && d.supported_keys().is_some_and(|k| {
+                        k.contains(evdev::Key::KEY_PAGEUP) && k.contains(evdev::Key::KEY_PAGEDOWN)
+                    })
+            })
+        })
+        .collect();
+    found.sort();
+    found.into_iter().next()
 }
 
 fn tap(dev: &mut File, code: u16) -> io::Result<()> {

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -1,26 +1,45 @@
 use log::{info, warn};
+use nix::sys::stat::Mode;
+use nix::unistd::mkfifo;
 use nix::{ioctl_none, ioctl_read_buf, ioctl_write_int};
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::mem;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{self, Command};
+use std::thread;
 
 const UINPUT_DEV: &str = "/dev/uinput";
 const TARGET_FILE: &str = "/var/run/kindle-button-mapper-key-target";
+const FIFO_PATH: &str = "/var/run/kindle-button-mapper-key.fifo";
+const FIFO_OWNER: &str = "/var/run/kindle-button-mapper-key-owner";
 const SYSFS_INPUT: &str = "/sys/devices/virtual/input";
 const DEV_INPUT: &str = "/dev/input";
 const DEV_NAME: &[u8] = b"kindle-button-mapper";
 
 const UINPUT_MAX_NAME_SIZE: usize = 80;
 const ABS_CNT: usize = 64;
-const EV_KEY: u32 = 0x01;
+const EV_KEY: u16 = 0x01;
+const EV_SYN: u16 = 0x00;
+const SYN_REPORT: u16 = 0x00;
 
 ioctl_none!(ui_dev_create, b'U', 1);
 ioctl_write_int!(ui_set_evbit, b'U', 100);
 ioctl_write_int!(ui_set_keybit, b'U', 101);
 ioctl_read_buf!(ui_get_sysname, b'U', 44, u8);
+
+// Kernel layout: the timestamp is a pair of kernel longs, not libc time_t —
+// musl 1.2 widened time_t to 64 bits on 32-bit ARM, which would make this
+// struct 8 bytes too long and every write fail with EINVAL.
+#[repr(C)]
+struct InputEvent {
+    tv_sec: isize,
+    tv_usec: isize,
+    kind: u16,
+    code: u16,
+    value: i32,
+}
 
 #[repr(C)]
 struct InputId {
@@ -70,11 +89,96 @@ pub fn try_init() -> Option<File> {
     Some(file)
 }
 
+/// Serve key injection requests on a FIFO, one key name (or code) per line.
+///
+/// scripts/key.sh writes to it, so nothing on the device needs an external
+/// injector binary — evemu-event is not shipped on stock firmware.
+pub fn serve(dev: File) {
+    // A FIFO left behind by a crashed daemon would block writers forever.
+    let _ = fs::remove_file(FIFO_PATH);
+    if let Err(e) = mkfifo(FIFO_PATH, Mode::from_bits_truncate(0o600)) {
+        warn!("Cannot create {}: {} — key injection unavailable", FIFO_PATH, e);
+        return;
+    }
+    // key.sh checks this pid before writing: opening a FIFO nobody reads blocks.
+    if let Err(e) = fs::write(FIFO_OWNER, process::id().to_string()) {
+        warn!("Cannot write {}: {}", FIFO_OWNER, e);
+    }
+    info!("Key injection FIFO at {}", FIFO_PATH);
+    thread::Builder::new()
+        .name("keyfifo".into())
+        .spawn(move || fifo_loop(dev))
+        .map(|_| ())
+        .unwrap_or_else(|e| warn!("Cannot spawn key FIFO thread: {}", e));
+}
+
+fn fifo_loop(mut dev: File) {
+    loop {
+        // Read/write so a writer closing does not end the loop, and so key.sh
+        // never blocks on open while the daemon is alive.
+        let fifo = match OpenOptions::new().read(true).write(true).open(FIFO_PATH) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!("Cannot open {}: {} — key injection stopped", FIFO_PATH, e);
+                return;
+            }
+        };
+        for line in BufReader::new(fifo).lines() {
+            match line {
+                Ok(l) => handle_request(&mut dev, l.trim()),
+                Err(e) => {
+                    warn!("{} read failed: {}", FIFO_PATH, e);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn handle_request(dev: &mut File, line: &str) {
+    if line.is_empty() {
+        return;
+    }
+    match crate::config::parse_key(line) {
+        Some(key) => {
+            if let Err(e) = tap(dev, key.code()) {
+                warn!("Injecting {} failed: {}", line, e);
+            }
+        }
+        None => warn!("Key FIFO: unknown key {:?}", line),
+    }
+}
+
+fn tap(dev: &mut File, code: u16) -> io::Result<()> {
+    write_event(dev, EV_KEY, code, 1)?;
+    write_event(dev, EV_SYN, SYN_REPORT, 0)?;
+    write_event(dev, EV_KEY, code, 0)?;
+    write_event(dev, EV_SYN, SYN_REPORT, 0)
+}
+
+fn write_event(dev: &mut File, kind: u16, code: u16, value: i32) -> io::Result<()> {
+    // The kernel stamps the time itself, so leaving it zero is fine.
+    let ev = InputEvent {
+        tv_sec: 0,
+        tv_usec: 0,
+        kind,
+        code,
+        value,
+    };
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            (&ev as *const InputEvent).cast::<u8>(),
+            mem::size_of::<InputEvent>(),
+        )
+    };
+    dev.write_all(bytes)
+}
+
 fn create_device() -> io::Result<File> {
     let file = OpenOptions::new().read(true).write(true).open(UINPUT_DEV)?;
     let fd = file.as_raw_fd();
 
-    unsafe { ui_set_evbit(fd, EV_KEY as _) }?;
+    unsafe { ui_set_evbit(fd, EV_KEY as u32 as _) }?;
     for code in supported_keys() {
         unsafe { ui_set_keybit(fd, code as _) }?;
     }

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -268,7 +268,9 @@ fn ensure_event_node(path: &Path, sysdir: &Path) -> io::Result<()> {
     let status = Command::new("mknod")
         .args([&path.display().to_string(), "c", major, minor])
         .status()?;
-    if !status.success() {
+    // devtmpfs can beat us to the node between the check above and here, and
+    // that mknod failure is not one worth losing the keyboard over.
+    if !status.success() && !path.exists() {
         return Err(io::Error::other(format!(
             "mknod {} exit {}",
             path.display(),

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -13,8 +13,17 @@ const INITCTL: &str = "/sbin/initctl";
 const SERVICE: &str = "kindle-button-mapper";
 
 // (kind, id, label) — kind matches the tab in the WAF action picker and
-// selects the script the binding is written against.
+// selects the script the binding is written against. "auto" routes at press
+// time: KOReader when it is up, the native reader otherwise.
 const ACTIONS: &[(&str, &str, &str)] = &[
+    ("auto", "next_page", "Next page"),
+    ("auto", "prev_page", "Previous page"),
+    ("auto", "menu", "Menu / toolbar"),
+    ("auto", "brightness 1", "Brightness +1"),
+    ("auto", "brightness -1", "Brightness -1"),
+    ("auto", "brightness 5", "Brightness +5"),
+    ("auto", "brightness -5", "Brightness -5"),
+    ("auto", "brightness_toggle", "Toggle frontlight"),
     ("kindle", "next_page", "Next page"),
     ("kindle", "prev_page", "Previous page"),
     ("kindle", "home", "Home screen"),


### PR DESCRIPTION
Follow ups on the three things @evanmang and @danergo hit after #32, plus the old kernel fix that already landed in #31.

`kindle.sh` was missing from the CI artifact because the workflow listed the scripts one by one, so it now copies whatever is in `scripts/` and the manifest check does the same.

The page turns failing is the interesting one. `key.sh` was shelling out to `evemu-event`, which isnt on stock firmware, and it printed the same "virtual keyboard is not running" warning whether the device was missing or the binary was. The daemon holds the uinput fd anyway, so it does the injecting itself now, reading key names off `/var/run/kindle-button-mapper-key.fifo`. Nothing extra to install on the device. The old `evemu-event` path stays as a fallback for a daemon that predates the FIFO. While in there I also fixed the event struct, which used libc `time_t` and would have been 8 bytes too long on musl 1.2.

For the bindings replacing each other, a button holds one script, so a KOReader action always clobbered the Kindle one. New `scripts/auto.sh` decides at press time, going to KOReader when it answers on its HTTP Inspector port and falling back to the native reader, so a single binding covers both. MapperManager opens on an Auto tab now and the two per reader tabs stay for anyone who wants a button pinned to one of them.

I cant test uinput on my dev box and my Basic 5 is offline right now, so the injection path is unverified on hardware. @evanmang @danergo if you can grab the CI artifact from this PR it would help a lot, especially the page turns on the KO3 with the #31 fix in.
