### PR TITLE
Turn pages on key down, without a shell per press

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ otherwise the device `name`. Set at least one.
 
 Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to type correctly on a non-US Bluetooth keyboard. The reader re-pins the `us` core keymap on every focus and `/usr/share/X11/xkb` is read-only, so the mapper bind-mounts a generated `us` symbols file over the system one; every re-pin then resolves to your layout, reverted when the daemon stops. Give a comma list for an Alt+Shift toggle (`us,ru`); it's a system-wide override taken from the first device that sets one. Leave it unset to keep the system default.
 
+A button fires as soon as it goes down. Give it a `longpress` mapping and it
+fires on release instead, since a short press is only a short press once you
+let go.
+
 Use `log_buttons = true` to discover button codes for your device.
 
 ### Reader actions
@@ -113,9 +117,16 @@ Three helper scripts ship with the mapper, so a binding can drive either reader:
 | Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `next_page_tap`, `prev_page_tap`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
 
 `auto.sh` is what the Auto tab in MapperManager writes, and it is the one to use
-if you read in both: it checks whether KOReader is answering on its HTTP
-Inspector port and routes there, falling back to the native reader. One binding
-per button covers both readers.
+if you read in both: it sends the event to KOReader's HTTP Inspector and falls
+back to the native reader when nothing is listening there. One binding per
+button covers both readers.
+
+The daemon recognises those three scripts and runs the page-turn and reader
+events itself — a socket write, or a write to the injector it already owns —
+instead of forking a shell and a `curl` per press. A binding it does not
+recognise, including anything of your own and the `lipc` actions, still runs as
+a shell command. The scripts stay the interface, so a binding works the same
+from a terminal.
 
 Page turns are injected rather than driven by the UI, so there are no
 coordinates to get wrong.

--- a/scripts/auto.sh
+++ b/scripts/auto.sh
@@ -11,34 +11,32 @@
 #   brightness_toggle - Toggle frontlight off/on
 #   menu              - KOReader menu, native toolbar
 #
-# KOReader answers on its HTTP Inspector port when it is up, so a reachable
-# port means it is the reader in front of you. Everything else, including the
+# KOReader answers on its HTTP Inspector port when it is up, so a delivered
+# event means it is the reader in front of you. Trying it is the probe — a
+# separate one would only cost another curl. Everything else, including the
 # native-only commands (home, back, toolbar), goes to kindle.sh. The tap
 # variants only change how the native side turns the page, KOReader still gets
 # the HTTP event.
 
 DIR=$(dirname "$0")
-KOREADER_PROBE="http://localhost:8080/"
 
-koreader_up() {
-    curl -s --connect-timeout 1 -o /dev/null "$KOREADER_PROBE" 2>/dev/null
+try_koreader() {
+    KBM_QUIET=1 "$DIR/koreader.sh" "$@"
 }
 
 CMD="$1"
 case "$CMD" in
     next_page|prev_page|brightness|brightness_toggle|night_mode|font_up|font_down|toggle_status_bar|rotate)
-        koreader_up && exec "$DIR/koreader.sh" "$@"
+        try_koreader "$@" && exit 0
         ;;
     next_page_tap)
-        koreader_up && exec "$DIR/koreader.sh" next_page
+        try_koreader next_page && exit 0
         ;;
     prev_page_tap)
-        koreader_up && exec "$DIR/koreader.sh" prev_page
+        try_koreader prev_page && exit 0
         ;;
     menu)
-        if koreader_up; then
-            exec "$DIR/koreader.sh" menu
-        fi
+        try_koreader menu && exit 0
         exec "$DIR/kindle.sh" toolbar
         ;;
     "")

--- a/scripts/koreader.sh
+++ b/scripts/koreader.sh
@@ -15,11 +15,15 @@
 KOREADER_URL="http://localhost:8080/koreader/event"
 LOG_PATH="/var/log/kindle-button-mapper.log"
 
-# Send event to KOReader
+# Send event to KOReader. Exits non-zero when it did not land, which is what
+# lets auto.sh fall back to the native reader. KBM_QUIET=1 silences the warning
+# for callers that have a fallback.
 send_event() {
-    if ! curl -s --connect-timeout 1 "${KOREADER_URL}/$1" >/dev/null 2>&1; then
-        echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  koreader.sh: KOReader not reachable at ${KOREADER_URL} (event '$1' dropped); KOReader may be closed, or HTTP Inspector auto-start is off." >> "$LOG_PATH" 2>/dev/null
+    if curl -s --connect-timeout 1 "${KOREADER_URL}/$1" >/dev/null 2>&1; then
+        return 0
     fi
+    [ -z "$KBM_QUIET" ] && echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  koreader.sh: KOReader not reachable at ${KOREADER_URL} (event '$1' dropped); KOReader may be closed, or HTTP Inspector auto-start is off." >> "$LOG_PATH" 2>/dev/null
+    return 1
 }
 
 case "$1" in

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,0 +1,162 @@
+use crate::{koreader, vkeyboard};
+use log::{debug, error};
+use std::process::Command;
+use std::sync::mpsc::{self, Sender};
+use std::sync::OnceLock;
+use std::thread;
+
+/// Steps run in order until one lands, which is how `auto.sh` picks a reader.
+#[derive(Debug, PartialEq)]
+enum Step {
+    Koreader(String),   // HTTP Inspector event path, e.g. GotoViewRel/1
+    Key(&'static str),  // injection request, e.g. page_next
+}
+
+/// Run a configured action. The shipped reader scripts are handled in-process —
+/// a `/bin/sh` plus a `curl` per press costs more than the page turn itself.
+/// Everything else goes to the shell.
+pub fn run(script: &str) {
+    match plan(script) {
+        Some(steps) => queue(script.to_string(), steps),
+        None => spawn_shell(script),
+    }
+}
+
+/// Run a shell command line, without waiting for it.
+pub fn spawn_shell(script: &str) {
+    match Command::new("/bin/sh").args(["-c", script]).spawn() {
+        Ok(mut child) => {
+            // Reap elsewhere, no zombies.
+            thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
+        Err(e) => error!("Failed to execute '{}': {}", script, e),
+    }
+}
+
+/// One thread, so a held button cannot overtake itself and the event loop
+/// never waits on a socket.
+fn queue(script: String, steps: Vec<Step>) {
+    static QUEUE: OnceLock<Sender<(String, Vec<Step>)>> = OnceLock::new();
+    let tx = QUEUE.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<(String, Vec<Step>)>();
+        thread::Builder::new()
+            .name("actions".into())
+            .spawn(move || {
+                for (script, steps) in rx {
+                    execute(&script, &steps);
+                }
+            })
+            .expect("spawn action thread");
+        tx
+    });
+    if let Err(e) = tx.send((script, steps)) {
+        error!("Action thread is gone: {}", e);
+    }
+}
+
+fn execute(script: &str, steps: &[Step]) {
+    for step in steps {
+        match step {
+            Step::Koreader(event) => {
+                if koreader::send_event(event) {
+                    return;
+                }
+            }
+            Step::Key(request) => {
+                if vkeyboard::inject(request) {
+                    return;
+                }
+                // Nothing to inject into on this firmware, so hand it back to
+                // the script, which taps the screen instead.
+                spawn_shell(script);
+                return;
+            }
+        }
+    }
+    debug!("No step of {:?} landed", steps);
+}
+
+/// Translate the shipped reader scripts into steps. Shell syntax, an unknown
+/// script or anything needing lipc returns None and stays a shell call.
+fn plan(script: &str) -> Option<Vec<Step>> {
+    if script.contains(|c| "|&;<>()$`\\\"'*?[#~=%\n".contains(c)) {
+        return None;
+    }
+    let mut words = script.split_whitespace();
+    let path = words.next()?;
+    let name = path.rsplit('/').next()?;
+    let cmd = words.next()?;
+    if words.next().is_some() {
+        return None; // takes an argument (brightness, font size) — not a hot path
+    }
+
+    match name {
+        "koreader.sh" => Some(vec![Step::Koreader(koreader_event(cmd)?.to_string())]),
+        "kindle.sh" => Some(vec![Step::Key(native_key(cmd)?)]),
+        "auto.sh" => Some(vec![
+            Step::Koreader(koreader_event(cmd)?.to_string()),
+            Step::Key(native_key(cmd)?),
+        ]),
+        _ => None,
+    }
+}
+
+fn koreader_event(cmd: &str) -> Option<&'static str> {
+    match cmd {
+        "next_page" => Some("GotoViewRel/1"),
+        "prev_page" => Some("GotoViewRel/-1"),
+        "brightness_toggle" => Some("ToggleFrontlight"),
+        "night_mode" => Some("ToggleNightMode"),
+        "menu" => Some("ShowMenu"),
+        "toggle_status_bar" => Some("ToggleFooterMode"),
+        "rotate" => Some("IterateRotation"),
+        _ => None,
+    }
+}
+
+fn native_key(cmd: &str) -> Option<&'static str> {
+    match cmd {
+        "next_page" => Some("page_next"),
+        "prev_page" => Some("page_prev"),
+        "home" => Some("KEY_HOME"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_turns_are_planned() {
+        assert_eq!(
+            plan("/mnt/us/kindle-button-mapper/scripts/kindle.sh next_page"),
+            Some(vec![Step::Key("page_next")])
+        );
+        assert_eq!(
+            plan("scripts/koreader.sh prev_page"),
+            Some(vec![Step::Koreader("GotoViewRel/-1".into())])
+        );
+        assert_eq!(
+            plan("/mnt/us/kindle-button-mapper/scripts/auto.sh next_page"),
+            Some(vec![
+                Step::Koreader("GotoViewRel/1".into()),
+                Step::Key("page_next"),
+            ])
+        );
+    }
+
+    #[test]
+    fn lipc_and_user_scripts_stay_shell() {
+        // auto.sh menu falls back to the native toolbar over lipc
+        assert_eq!(plan("scripts/auto.sh menu"), None);
+        assert_eq!(plan("scripts/kindle.sh toolbar"), None);
+        assert_eq!(plan("scripts/koreader.sh brightness 2"), None);
+        assert_eq!(plan("scripts/auto.sh next_page && echo hi"), None);
+        assert_eq!(plan("lipc-set-prop com.lab126.powerd flIntensity 5"), None);
+        assert_eq!(plan("/mnt/us/my-script.sh next_page"), None);
+        assert_eq!(plan(""), None);
+    }
+}

--- a/src/koreader.rs
+++ b/src/koreader.rs
@@ -1,0 +1,55 @@
+use log::{debug, warn};
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
+use std::time::Duration;
+
+const PORT: u16 = 8080;
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
+const WRITE_TIMEOUT: Duration = Duration::from_millis(300);
+const READ_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// Send an event to KOReader's HTTP Inspector, e.g. `GotoViewRel/1`. False
+/// means KOReader did not take it, so the caller can try the native reader.
+/// The inspector closes the connection after every response, so there is
+/// nothing to keep alive between calls.
+pub fn send_event(event: &str) -> bool {
+    let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, PORT));
+    let mut stream = match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("KOReader not reachable on port {}: {}", PORT, e);
+            return false;
+        }
+    };
+    let _ = stream.set_nodelay(true);
+    let _ = stream.set_write_timeout(Some(WRITE_TIMEOUT));
+    let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+
+    let req = format!(
+        "GET /koreader/event/{} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        event, PORT
+    );
+    if let Err(e) = stream.write_all(req.as_bytes()) {
+        debug!("KOReader event '{}' not sent: {}", event, e);
+        return false;
+    }
+
+    // KOReader only polls the socket on its 50ms UI tick, so the reply lags.
+    // The request is delivered either way, so a timeout still counts as taken.
+    let mut buf = [0u8; 64];
+    match stream.read(&mut buf) {
+        Ok(0) => debug!("KOReader closed without a reply to '{}'", event),
+        Ok(n) => match status_code(&buf[..n]) {
+            Some(code) if (200..300).contains(&code) => debug!("KOReader {} -> {}", event, code),
+            Some(code) => warn!("KOReader rejected event '{}' with HTTP {}", event, code),
+            None => warn!("KOReader sent no HTTP status for event '{}'", event),
+        },
+        Err(e) => debug!("No reply from KOReader for '{}': {}", event, e),
+    }
+    true
+}
+
+fn status_code(response: &[u8]) -> Option<u16> {
+    let head = std::str::from_utf8(response).ok()?;
+    head.split_whitespace().nth(1)?.parse().ok()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+mod action;
 mod config;
 mod input;
+mod koreader;
 mod layout;
 mod mapper;
 mod pause;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,8 +1,8 @@
+use crate::action;
 use crate::config::{DeviceConfig, DpadDirection, Trigger};
 use evdev::Key;
 use log::{debug, info};
 use std::collections::HashMap;
-use std::process::Command;
 use std::time::{Duration, Instant};
 
 pub struct Mapper {
@@ -19,6 +19,7 @@ pub struct Mapper {
     last_press: HashMap<Key, Instant>,
     press_start: HashMap<Key, Instant>,
     long_press_fired: HashMap<Key, bool>,
+    fired_on_press: HashMap<Key, bool>,
     last_repeat: HashMap<Key, Instant>,
     last_dpad: HashMap<DpadDirection, Instant>,
     last_trigger: HashMap<Trigger, Instant>,
@@ -55,6 +56,7 @@ impl Mapper {
             last_press: HashMap::new(),
             press_start: HashMap::new(),
             long_press_fired: HashMap::new(),
+            fired_on_press: HashMap::new(),
             last_repeat: HashMap::new(),
             last_dpad: HashMap::new(),
             last_trigger: HashMap::new(),
@@ -80,6 +82,23 @@ impl Mapper {
         self.last_press.insert(key, Instant::now());
         self.press_start.insert(key, Instant::now());
         self.long_press_fired.insert(key, false);
+
+        // Fire on the way down. A key with a long press mapping has to wait for
+        // the release to tell the two apart.
+        if self.long_press_mappings.contains_key(&key) {
+            return;
+        }
+        if let Some(script) = self.mappings.get(&key) {
+            if self.log_buttons {
+                info!("Button: {:?} (code: {}) -> {}", key, key.code(), script);
+            }
+            execute_script(script);
+            self.fired_on_press.insert(key, true);
+            self.last_repeat.insert(key, Instant::now());
+        } else if self.log_buttons {
+            // Log unmapped buttons for debugging
+            info!("Button: {:?} (code: {}) [unmapped]", key, key.code());
+        }
     }
 
     pub fn handle_held(&mut self, key: Key) {
@@ -131,7 +150,13 @@ impl Mapper {
         // must not fire the action either.
         let had_press = self.press_start.remove(&key).is_some();
         let long_press_fired = self.long_press_fired.remove(&key).unwrap_or(false);
+        let fired_on_press = self.fired_on_press.remove(&key).unwrap_or(false);
         self.last_repeat.remove(&key);
+
+        if fired_on_press {
+            debug!("Skipping release for {:?} (already fired on press)", key);
+            return;
+        }
 
         if !had_press {
             debug!("Skipping release for {:?} (press was debounced)", key);
@@ -349,16 +374,5 @@ impl Mapper {
 }
 
 fn execute_script(script: &str) {
-    // Always use shell to handle arguments properly
-    match Command::new("/bin/sh").args(["-c", script]).spawn() {
-        Ok(mut child) => {
-            // Spawn thread to wait for child to avoid zombies
-            std::thread::spawn(move || {
-                let _ = child.wait();
-            });
-        }
-        Err(e) => {
-            log::error!("Failed to execute '{}': {}", script, e);
-        }
-    }
+    action::run(script);
 }

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 
 const UINPUT_DEV: &str = "/dev/uinput";
@@ -94,6 +95,25 @@ pub fn try_init() -> Option<File> {
     Some(file)
 }
 
+/// Shared by the FIFO thread and in-process callers.
+static INJECTOR: OnceLock<Mutex<Injector>> = OnceLock::new();
+
+struct Injector {
+    dev: Option<File>,
+    pager: Pager,
+}
+
+/// Inject a key name, a key code, `page_next` or `page_prev`. False means there
+/// is nothing to inject into, so the caller can fall back to a tap.
+pub fn inject(request: &str) -> bool {
+    let Some(injector) = INJECTOR.get() else {
+        return false;
+    };
+    let mut injector = injector.lock().unwrap_or_else(|p| p.into_inner());
+    injector.handle(request.trim());
+    true
+}
+
 /// Serve key injection requests on a FIFO, one key name (or code) per line.
 ///
 /// scripts/key.sh writes to it, so nothing on the device needs an external
@@ -107,6 +127,10 @@ pub fn serve(dev: Option<File>) {
     let pager = Pager::find();
     if dev.is_none() && matches!(pager, Pager::VirtualKeyboard) {
         warn!("No page buttons and no uinput keyboard — nothing to inject into, use the tap page turn actions");
+        return;
+    }
+    if INJECTOR.set(Mutex::new(Injector { dev, pager })).is_err() {
+        warn!("Virtual keyboard already serving");
         return;
     }
 
@@ -123,12 +147,12 @@ pub fn serve(dev: Option<File>) {
     info!("Key injection FIFO at {}", FIFO_PATH);
     thread::Builder::new()
         .name("keyfifo".into())
-        .spawn(move || fifo_loop(dev, pager))
+        .spawn(fifo_loop)
         .map(|_| ())
         .unwrap_or_else(|e| warn!("Cannot spawn key FIFO thread: {}", e));
 }
 
-fn fifo_loop(mut dev: Option<File>, mut pager: Pager) {
+fn fifo_loop() {
     loop {
         // Read/write so a writer closing does not end the loop, and so key.sh
         // never blocks on open while the daemon is alive.
@@ -141,7 +165,9 @@ fn fifo_loop(mut dev: Option<File>, mut pager: Pager) {
         };
         for line in BufReader::new(fifo).lines() {
             match line {
-                Ok(l) => handle_request(&mut dev, &mut pager, l.trim()),
+                Ok(l) => {
+                    inject(&l);
+                }
                 Err(e) => {
                     warn!("{} read failed: {}", FIFO_PATH, e);
                     break;
@@ -151,22 +177,25 @@ fn fifo_loop(mut dev: Option<File>, mut pager: Pager) {
     }
 }
 
-fn handle_request(dev: &mut Option<File>, pager: &mut Pager, line: &str) {
-    match line {
-        "" => (),
-        "page_next" => pager.turn(dev.as_mut(), KEY_PAGEDOWN, KEY_DOWN),
-        "page_prev" => pager.turn(dev.as_mut(), KEY_PAGEUP, KEY_UP),
-        _ => match crate::config::parse_key(line) {
-            Some(key) => match dev {
-                Some(vkbd) => {
-                    if let Err(e) = tap(vkbd, key.code()) {
-                        warn!("Injecting {} failed: {}", line, e);
+impl Injector {
+    fn handle(&mut self, line: &str) {
+        let Injector { dev, pager } = self;
+        match line {
+            "" => (),
+            "page_next" => pager.turn(dev.as_mut(), KEY_PAGEDOWN, KEY_DOWN),
+            "page_prev" => pager.turn(dev.as_mut(), KEY_PAGEUP, KEY_UP),
+            _ => match crate::config::parse_key(line) {
+                Some(key) => match dev {
+                    Some(vkbd) => {
+                        if let Err(e) = tap(vkbd, key.code()) {
+                            warn!("Injecting {} failed: {}", line, e);
+                        }
                     }
-                }
-                None => warn!("Cannot inject {}, no uinput keyboard", line),
+                    None => warn!("Cannot inject {}, no uinput keyboard", line),
+                },
+                None => warn!("Key injection: unknown key {:?}", line),
             },
-            None => warn!("Key FIFO: unknown key {:?}", line),
-        },
+        }
     }
 }
 


### PR DESCRIPTION
Page turns felt sluggish next to the KOReader plugin. Three things stacked up.

The action fired on key *release*, so nothing happened until you lifted your thumb. Then it forked `/bin/sh`, then `auto.sh` ran a probe `curl` just to decide which reader was on screen, then `exec`ed `koreader.sh` for a second `curl` with the actual event. Five processes off vfat per page turn.

Buttons now fire on the way down. A key with a `longpress` mapping still waits for the release, since that is the only way to tell a short press from a long one.

The daemon also recognises the shipped `auto.sh`, `kindle.sh` and `koreader.sh` reader commands and runs them in process, a loopback GET to the inspector or a write to the injector it already owns, so nothing forks. `auto.sh next_page` becomes "try KOReader, else inject the page key". Shell syntax, your own scripts and the lipc actions (`toolbar`, `back`, `brightness`, `auto.sh menu`) still run as shell commands, so the scripts stay the interface.

`auto.sh` lost its probe `curl` and just tries KOReader, falling back to the native reader when the event does not land. `koreader.sh` returns curl status now so that works, quiet under `KBM_QUIET`.

No keep-alive, KOReader closes the client socket after every response, and the 50ms inspector poll is KOReader side and still there.

`cargo test` and `cargo clippy` pass and it builds for `armv7-unknown-linux-musleabihf`. Not timed on device yet, so if anyone has a controller paired, eyeballing it against the old build would help.