### PR TITLE
Add tap page turns for readers that ignore keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,30 @@ Three helper scripts ship with the mapper, so a binding can drive either reader:
 |---|---|---|---|
 | How it talks to the reader | picks one of the two below | virtual keyboard + `lipc` | HTTP Inspector on `localhost:8080` |
 | Setup needed | none | none | HTTP Inspector auto-start |
-| Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
+| Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `next_page_tap`, `prev_page_tap`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
 
 `auto.sh` is what the Auto tab in MapperManager writes, and it is the one to use
 if you read in both: it checks whether KOReader is answering on its HTTP
 Inspector port and routes there, falling back to the native reader. One binding
 per button covers both readers.
 
-Page turns are injected, not tapped, so there are no coordinates to get wrong.
+Page turns are injected rather than driven by the UI, so there are no
+coordinates to get wrong.
 The daemon reads requests off `/var/run/kindle-button-mapper-key.fifo`, which is
 how `scripts/key.sh` works without any external tool, and it picks the device.
 On a model with physical page buttons the framework only turns pages for that
 node, so the daemon writes `KEY_PAGEDOWN`/`KEY_PAGEUP` straight into it and the
 reader sees a normal button press. Everywhere else the native reader takes
 `KEY_DOWN` as next page and `KEY_UP` as previous page on the virtual keyboard.
+
+Some firmware ignores injected keys altogether, so `next_page_tap` and
+`prev_page_tap` go in as a touch on the screen instead, near the right and left
+edges. That one runs entirely in `scripts/tap.sh`, which finds the panel in
+`/proc/bus/input/devices`, takes the screen size from the framebuffer and
+writes the events itself, no daemon involved. Only reach for these if the plain
+page turn does nothing, since a tap follows whatever tap zones you have set in
+the reader.
+
 Everything else goes over `lipc`.
 
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.

--- a/scripts/auto.sh
+++ b/scripts/auto.sh
@@ -5,13 +5,17 @@
 # Commands:
 #   next_page         - Turn to next page
 #   prev_page         - Turn to previous page
+#   next_page_tap     - Next page, tapping the screen on the native reader
+#   prev_page_tap     - Previous page, tapping the screen on the native reader
 #   brightness <n>    - Adjust frontlight (positive=up, negative=down)
 #   brightness_toggle - Toggle frontlight off/on
 #   menu              - KOReader menu, native toolbar
 #
 # KOReader answers on its HTTP Inspector port when it is up, so a reachable
 # port means it is the reader in front of you. Everything else, including the
-# native-only commands (home, back, toolbar), goes to kindle.sh.
+# native-only commands (home, back, toolbar), goes to kindle.sh. The tap
+# variants only change how the native side turns the page, KOReader still gets
+# the HTTP event.
 
 DIR=$(dirname "$0")
 KOREADER_PROBE="http://localhost:8080/"
@@ -25,6 +29,12 @@ case "$CMD" in
     next_page|prev_page|brightness|brightness_toggle|night_mode|font_up|font_down|toggle_status_bar|rotate)
         koreader_up && exec "$DIR/koreader.sh" "$@"
         ;;
+    next_page_tap)
+        koreader_up && exec "$DIR/koreader.sh" next_page
+        ;;
+    prev_page_tap)
+        koreader_up && exec "$DIR/koreader.sh" prev_page
+        ;;
     menu)
         if koreader_up; then
             exec "$DIR/koreader.sh" menu
@@ -33,7 +43,8 @@ case "$CMD" in
         ;;
     "")
         echo "Usage: $0 <command> [args...]"
-        echo "Commands: next_page, prev_page, brightness <n>, brightness_toggle, menu"
+        echo "Commands: next_page, prev_page, next_page_tap, prev_page_tap,"
+        echo "          brightness <n>, brightness_toggle, menu"
         exit 1
         ;;
 esac

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -5,6 +5,8 @@
 # Commands:
 #   next_page         - Turn to next page
 #   prev_page         - Turn to previous page
+#   next_page_tap     - Turn to next page by tapping the screen
+#   prev_page_tap     - Turn to previous page by tapping the screen
 #   home              - Go to the home screen
 #   back              - Back / close the current view
 #   toolbar           - Toggle the reader toolbar
@@ -13,7 +15,8 @@
 #
 # Page turns are handed to the daemon, which injects into the physical page
 # buttons on models that have them and falls back to KEY_DOWN/KEY_UP on its
-# virtual keyboard everywhere else. The rest is lipc.
+# virtual keyboard everywhere else. The tap variants are for readers that
+# ignore keys entirely, and go through tap.sh. The rest is lipc.
 
 DIR=$(dirname "$0")
 LOG_PATH="/var/log/kindle-button-mapper.log"
@@ -37,6 +40,12 @@ case "$1" in
         ;;
     prev_page)
         send_key page_prev
+        ;;
+    next_page_tap)
+        "$DIR/tap.sh" 85 50 || warn "next_page_tap: cannot tap the screen"
+        ;;
+    prev_page_tap)
+        "$DIR/tap.sh" 12 50 || warn "prev_page_tap: cannot tap the screen"
         ;;
     home)
         send_key KEY_HOME
@@ -76,7 +85,8 @@ case "$1" in
         ;;
     *)
         echo "Usage: $0 <command> [args...]"
-        echo "Commands: next_page, prev_page, home, back, toolbar,"
+        echo "Commands: next_page, prev_page, next_page_tap, prev_page_tap,"
+        echo "          home, back, toolbar,"
         echo "          brightness <n>, brightness_toggle"
         exit 1
         ;;

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -15,8 +15,10 @@
 #
 # Page turns are handed to the daemon, which injects into the physical page
 # buttons on models that have them and falls back to KEY_DOWN/KEY_UP on its
-# virtual keyboard everywhere else. The tap variants are for readers that
-# ignore keys entirely, and go through tap.sh. The rest is lipc.
+# virtual keyboard everywhere else. Where there is no key path at all, they tap
+# instead. The tap variants force that for readers that take the keys but
+# ignore them, which nothing here can tell apart from a key that worked. Both
+# go through tap.sh. The rest is lipc.
 
 DIR=$(dirname "$0")
 LOG_PATH="/var/log/kindle-button-mapper.log"
@@ -27,7 +29,21 @@ warn() {
 }
 
 send_key() {
-    err=$("$DIR/key.sh" "$1" 2>&1) || warn "cannot inject $1: ${err:-unknown error}"
+    err=$("$DIR/key.sh" "$1" 2>&1) && return 0
+    warn "cannot inject $1: ${err:-unknown error}"
+    return 1
+}
+
+# Quiet, since the caller falls back to a tap and a device with no key path at
+# all would otherwise log a line on every page turn. The daemon already says
+# why once at startup.
+try_key() {
+    "$DIR/key.sh" "$1" >/dev/null 2>&1
+}
+
+# Right edge for next, left edge for previous, both at mid height.
+tap_page() {
+    "$DIR/tap.sh" "$2" 50 || warn "$1: cannot tap the screen"
 }
 
 fl_get() { lipc-get-prop com.lab126.powerd flIntensity 2>/dev/null || echo 0; }
@@ -36,16 +52,16 @@ fl_set() { lipc-set-prop com.lab126.powerd flIntensity "$1" 2>/dev/null; }
 
 case "$1" in
     next_page)
-        send_key page_next
+        try_key page_next || tap_page next_page 85
         ;;
     prev_page)
-        send_key page_prev
+        try_key page_prev || tap_page prev_page 12
         ;;
     next_page_tap)
-        "$DIR/tap.sh" 85 50 || warn "next_page_tap: cannot tap the screen"
+        tap_page next_page_tap 85
         ;;
     prev_page_tap)
-        "$DIR/tap.sh" 12 50 || warn "prev_page_tap: cannot tap the screen"
+        tap_page prev_page_tap 12
         ;;
     home)
         send_key KEY_HOME

--- a/scripts/tap.sh
+++ b/scripts/tap.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Tap the touchscreen.
+# Usage: tap.sh [X_PERCENT] [Y_PERCENT]
+#
+# Writes the input_event structs a real finger produces straight into the
+# touchscreen node, so it needs nothing but a shell. Codes the panel does not
+# support are dropped by the kernel, which is why the sequence can carry both
+# BTN_TOUCH and the pressure/contact axes and still suit either panel.
+
+X_PCT="${1:-85}"
+Y_PCT="${2:-50}"
+
+FB_MODES="/sys/class/graphics/fb0/modes"
+DEVICES="/proc/bus/input/devices"
+
+# The touchscreen is the direct-input device with absolute axes. A gamepad has
+# axes too, but reports no INPUT_PROP_DIRECT.
+touch_node() {
+    awk '
+        /^$/ { prop=""; abs=""; handler="" }
+        /^B: PROP=/ { prop=$2; sub(/PROP=/, "", prop) }
+        /^B: ABS=/  { abs=$2 }
+        /^H: Handlers=/ {
+            handler=""
+            for (i = 2; i <= NF; i++) {
+                t=$i; sub(/^Handlers=/, "", t)
+                if (t ~ /^event[0-9]+$/) handler=t
+            }
+        }
+        {
+            if (handler != "" && abs != "" && prop ~ /[23671abefABEF]$/) {
+                print "/dev/input/" handler
+                exit
+            }
+        }
+    ' "$DEVICES" 2>/dev/null
+}
+
+screen_size() {
+    # e.g. U:1072x1448p-0
+    sed -n 's/^[^:]*:\([0-9]*\)x\([0-9]*\).*/\1 \2/p' "$FB_MODES" 2>/dev/null | head -n 1
+}
+
+DEV=$(touch_node)
+[ -z "$DEV" ] && { echo "tap.sh: no touchscreen found" >&2; exit 1; }
+
+SIZE=$(screen_size)
+W=${SIZE% *}
+H=${SIZE#* }
+case "$W$H" in
+    ""|*[!0-9]*) echo "tap.sh: cannot read screen size from $FB_MODES" >&2; exit 1 ;;
+esac
+
+X=$(( W * X_PCT / 100 ))
+Y=$(( H * Y_PCT / 100 ))
+
+# Escape text rather than raw bytes, so the whole sequence goes out in one
+# write. evdev rejects a write that is not a whole number of events, and a
+# byte at a time is exactly that.
+byte() { printf '\\0%03o' $(( $1 & 255 )); }
+le16() { byte "$1"; byte "$(( $1 >> 8 ))"; }
+le32() { byte "$1"; byte "$(( $1 >> 8 ))"; byte "$(( $1 >> 16 ))"; byte "$(( $1 >> 24 ))"; }
+# The kernel stamps the time itself, so the timeval goes out as zeroes.
+ev() { le32 0; le32 0; le16 "$1"; le16 "$2"; le32 "$3"; }
+
+DOWN=$(
+    ev 1 330 1     # BTN_TOUCH down
+    ev 3 57 0      # ABS_MT_TRACKING_ID
+    ev 3 58 18     # ABS_MT_PRESSURE
+    ev 3 53 "$X"   # ABS_MT_POSITION_X
+    ev 3 54 "$Y"   # ABS_MT_POSITION_Y
+    ev 3 48 18     # ABS_MT_TOUCH_MAJOR
+    ev 3 50 18     # ABS_MT_WIDTH_MAJOR
+    ev 0 0 0       # SYN_REPORT
+)
+UP=$(
+    ev 1 330 0     # BTN_TOUCH up
+    ev 3 57 -1     # ABS_MT_TRACKING_ID, contact lifted
+    ev 0 0 0
+)
+
+printf '%b' "$DOWN" > "$DEV" || { echo "tap.sh: cannot write to $DEV" >&2; exit 1; }
+# busybox sleep takes whole seconds only, and holding a contact for a second
+# reads as a long press.
+usleep 80000 2>/dev/null
+printf '%b' "$UP" > "$DEV"

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,10 +88,10 @@ fn main() {
     }
 
     // Virtual keyboard via uinput — kept alive for the daemon's lifetime by the
-    // FIFO thread, which injects the keys scripts/key.sh asks for.
-    if let Some(dev) = vkeyboard::try_init() {
-        vkeyboard::serve(dev);
-    }
+    // FIFO thread, which injects the keys scripts/key.sh asks for. Page turns
+    // on a model with page buttons go into that node instead, so the FIFO is
+    // worth serving even where uinput is missing.
+    vkeyboard::serve(vkeyboard::try_init());
 
     // System-wide XKB override, set up once. First device that names a layout wins.
     let _layout = config

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -98,7 +98,18 @@ pub fn try_init() -> Option<File> {
 ///
 /// scripts/key.sh writes to it, so nothing on the device needs an external
 /// injector binary — evemu-event is not shipped on stock firmware.
-pub fn serve(dev: File) {
+///
+/// `dev` is the uinput keyboard, which is absent on firmware without the
+/// driver. Page turns still go in through the page buttons there, so the FIFO
+/// is only pointless when neither exists, and it stays unopened in that case so
+/// key.sh fails and scripts/kindle.sh can fall back to a tap.
+pub fn serve(dev: Option<File>) {
+    let pager = Pager::find();
+    if dev.is_none() && matches!(pager, Pager::VirtualKeyboard) {
+        warn!("No page buttons and no uinput keyboard — nothing to inject into, use the tap page turn actions");
+        return;
+    }
+
     // A FIFO left behind by a crashed daemon would block writers forever.
     let _ = fs::remove_file(FIFO_PATH);
     if let Err(e) = mkfifo(FIFO_PATH, Mode::from_bits_truncate(0o600)) {
@@ -112,13 +123,12 @@ pub fn serve(dev: File) {
     info!("Key injection FIFO at {}", FIFO_PATH);
     thread::Builder::new()
         .name("keyfifo".into())
-        .spawn(move || fifo_loop(dev))
+        .spawn(move || fifo_loop(dev, pager))
         .map(|_| ())
         .unwrap_or_else(|e| warn!("Cannot spawn key FIFO thread: {}", e));
 }
 
-fn fifo_loop(mut dev: File) {
-    let mut pager = Pager::find();
+fn fifo_loop(mut dev: Option<File>, mut pager: Pager) {
     loop {
         // Read/write so a writer closing does not end the loop, and so key.sh
         // never blocks on open while the daemon is alive.
@@ -141,17 +151,20 @@ fn fifo_loop(mut dev: File) {
     }
 }
 
-fn handle_request(dev: &mut File, pager: &mut Pager, line: &str) {
+fn handle_request(dev: &mut Option<File>, pager: &mut Pager, line: &str) {
     match line {
         "" => (),
-        "page_next" => pager.turn(dev, KEY_PAGEDOWN, KEY_DOWN),
-        "page_prev" => pager.turn(dev, KEY_PAGEUP, KEY_UP),
+        "page_next" => pager.turn(dev.as_mut(), KEY_PAGEDOWN, KEY_DOWN),
+        "page_prev" => pager.turn(dev.as_mut(), KEY_PAGEUP, KEY_UP),
         _ => match crate::config::parse_key(line) {
-            Some(key) => {
-                if let Err(e) = tap(dev, key.code()) {
-                    warn!("Injecting {} failed: {}", line, e);
+            Some(key) => match dev {
+                Some(vkbd) => {
+                    if let Err(e) = tap(vkbd, key.code()) {
+                        warn!("Injecting {} failed: {}", line, e);
+                    }
                 }
-            }
+                None => warn!("Cannot inject {}, no uinput keyboard", line),
+            },
             None => warn!("Key FIFO: unknown key {:?}", line),
         },
     }
@@ -183,7 +196,7 @@ impl Pager {
         }
     }
 
-    fn turn(&mut self, vkbd: &mut File, button_code: u16, kbd_code: u16) {
+    fn turn(&mut self, vkbd: Option<&mut File>, button_code: u16, kbd_code: u16) {
         match self {
             Pager::Buttons { path, node } => {
                 if node.is_none() {
@@ -202,11 +215,15 @@ impl Pager {
                     *node = None;
                 }
             }
-            Pager::VirtualKeyboard => {
-                if let Err(e) = tap(vkbd, kbd_code) {
-                    warn!("Page turn failed: {}", e);
+            Pager::VirtualKeyboard => match vkbd {
+                Some(vkbd) => {
+                    if let Err(e) = tap(vkbd, kbd_code) {
+                        warn!("Page turn failed: {}", e);
+                    }
                 }
-            }
+                // serve() does not open the FIFO in this case.
+                None => warn!("Page turn failed, no uinput keyboard"),
+            },
         }
     }
 }

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -26,6 +26,8 @@ const ACTIONS: &[(&str, &str, &str)] = &[
     ("auto", "brightness_toggle", "Toggle frontlight"),
     ("kindle", "next_page", "Next page"),
     ("kindle", "prev_page", "Previous page"),
+    ("kindle", "next_page_tap", "Next page (tap)"),
+    ("kindle", "prev_page_tap", "Previous page (tap)"),
     ("kindle", "home", "Home screen"),
     ("kindle", "back", "Back"),
     ("kindle", "toolbar", "Toggle toolbar"),

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -18,6 +18,8 @@ const SERVICE: &str = "kindle-button-mapper";
 const ACTIONS: &[(&str, &str, &str)] = &[
     ("auto", "next_page", "Next page"),
     ("auto", "prev_page", "Previous page"),
+    ("auto", "next_page_tap", "Next page (tap)"),
+    ("auto", "prev_page_tap", "Previous page (tap)"),
     ("auto", "menu", "Menu / toolbar"),
     ("auto", "brightness 1", "Brightness +1"),
     ("auto", "brightness -1", "Brightness -1"),


### PR DESCRIPTION
Follow up to #23. @evanmang's PW12 on FW 5.18.1 has no page buttons, so the gpio-keys path from #33 has nothing to write to, and its reader ignores KEY_DOWN from the virtual keyboard, so it is left with no page turn at all.

So taps are back, the way `nextPage.sh` did it before 2f4cfc4, except `scripts/tap.sh` builds the events instead of replaying a captured base64 blob. It finds the panel in `/proc/bus/input/devices` by looking for absolute axes on a direct input device, so a gamepad with axes doesnt get picked, takes the screen size from the framebuffer mode and places the tap by percentage. No daemon and no ioctl, just a shell writing to the node.

The sequence carries BTN_TOUCH along with the tracking id, position, pressure and contact size. The kernel drops codes a panel doesnt support, so the same events suit both the goodix panel on my basic 5 and the cyttsp5 in @evanmang's capture. Two details that cost me a round each, evdev rejects a write that isnt a whole number of events so the whole thing goes out in one printf, and busybox sleep only takes whole seconds, so a fractional fallback of 1s held the contact long enough to read as a long press. usleep does the 80ms instead.

Tested on my basic 5, the tap lands where asked and registers as a tap.

`next_page_tap` and `prev_page_tap` are their own actions in the Kindle tab rather than the default, a tap follows whatever tap zones you have set in the reader while a real page turn does not.

@evanmang could you grab the artifact and try them?
