### PR TITLE
Make a freshly paired gamepad work without hand-mapping every button

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -88,8 +88,19 @@ fn plan(script: &str) -> Option<Vec<Step>> {
     let path = words.next()?;
     let name = path.rsplit('/').next()?;
     let cmd = words.next()?;
+    let arg = words.next();
     if words.next().is_some() {
-        return None; // takes an argument (brightness, font size) — not a hot path
+        return None; // more than one argument is never a hot path
+    }
+
+    // `koreader.sh event <Name>` is any Dispatcher action the plugin offers,
+    // so it is the common case rather than an exotic one. Everything else
+    // taking an argument (brightness, font size) stays a shell call.
+    if let Some(arg) = arg {
+        if name == "koreader.sh" && cmd == "event" && is_event_name(arg) {
+            return Some(vec![Step::Koreader(arg.to_string())]);
+        }
+        return None;
     }
 
     match name {
@@ -104,6 +115,14 @@ fn plan(script: &str) -> Option<Vec<Step>> {
         ]),
         _ => None,
     }
+}
+
+/// A bare KOReader event name. Anything with a slash already carries its own
+/// argument and is left to the shell, which url-encodes it.
+fn is_event_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.starts_with(|c: char| c.is_ascii_alphabetic())
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Only what the injector itself accepts, so an unknown name still reaches
@@ -181,6 +200,27 @@ mod tests {
         );
         // Unknown names stay a shell call so key.sh can still try evemu.
         assert_eq!(plan("scripts/key.sh NOT_A_KEY"), None);
+    }
+
+    #[test]
+    fn koreader_events_are_planned() {
+        assert_eq!(
+            plan("/mnt/us/kindle-button-mapper/scripts/koreader.sh event ShowMenu"),
+            Some(vec![Step::Koreader("ShowMenu".into())])
+        );
+        assert_eq!(
+            plan("scripts/koreader.sh event ToggleNightMode"),
+            Some(vec![Step::Koreader("ToggleNightMode".into())])
+        );
+        // Already carries an argument, the shell url-encodes it.
+        assert_eq!(plan("scripts/koreader.sh event GotoViewRel/1"), None);
+        // Two arguments is never a hot path.
+        assert_eq!(plan("scripts/koreader.sh event Foo Bar"), None);
+        // The named shortcuts still work and win over the generic form.
+        assert_eq!(
+            plan("scripts/koreader.sh next_page"),
+            Some(vec![Step::Koreader("GotoViewRel/1".into())])
+        );
     }
 
     #[test]

--- a/src/action.rs
+++ b/src/action.rs
@@ -8,8 +8,8 @@ use std::thread;
 /// Steps run in order until one lands, which is how `auto.sh` picks a reader.
 #[derive(Debug, PartialEq)]
 enum Step {
-    Koreader(String),   // HTTP Inspector event path, e.g. GotoViewRel/1
-    Key(&'static str),  // injection request, e.g. page_next
+    Koreader(String), // HTTP Inspector event path, e.g. GotoViewRel/1
+    Key(String),      // injection request, e.g. page_next or KEY_LEFT
 }
 
 /// Run a configured action. The shipped reader scripts are handled in-process —
@@ -94,12 +94,24 @@ fn plan(script: &str) -> Option<Vec<Step>> {
 
     match name {
         "koreader.sh" => Some(vec![Step::Koreader(koreader_event(cmd)?.to_string())]),
-        "kindle.sh" => Some(vec![Step::Key(native_key(cmd)?)]),
+        "kindle.sh" => Some(vec![Step::Key(native_key(cmd)?.to_string())]),
+        // The FIFO round trip key.sh does ends in the same inject() call, so
+        // the shell only ever cost a fork. Held keys go through here.
+        "key.sh" => Some(vec![Step::Key(injectable(cmd)?)]),
         "auto.sh" => Some(vec![
             Step::Koreader(koreader_event(cmd)?.to_string()),
-            Step::Key(native_key(cmd)?),
+            Step::Key(native_key(cmd)?.to_string()),
         ]),
         _ => None,
+    }
+}
+
+/// Only what the injector itself accepts, so an unknown name still reaches
+/// key.sh and its evemu fallback rather than being dropped in-process.
+fn injectable(cmd: &str) -> Option<String> {
+    match cmd {
+        "page_next" | "page_prev" => Some(cmd.to_string()),
+        _ => crate::config::parse_key(cmd).map(|_| cmd.to_string()),
     }
 }
 
@@ -133,7 +145,7 @@ mod tests {
     fn page_turns_are_planned() {
         assert_eq!(
             plan("/mnt/us/kindle-button-mapper/scripts/kindle.sh next_page"),
-            Some(vec![Step::Key("page_next")])
+            Some(vec![Step::Key("page_next".into())])
         );
         assert_eq!(
             plan("scripts/koreader.sh prev_page"),
@@ -143,9 +155,32 @@ mod tests {
             plan("/mnt/us/kindle-button-mapper/scripts/auto.sh next_page"),
             Some(vec![
                 Step::Koreader("GotoViewRel/1".into()),
-                Step::Key("page_next"),
+                Step::Key("page_next".into()),
             ])
         );
+    }
+
+    #[test]
+    fn key_injection_is_planned() {
+        assert_eq!(
+            plan("/mnt/us/kindle-button-mapper/scripts/key.sh KEY_LEFT"),
+            Some(vec![Step::Key("KEY_LEFT".into())])
+        );
+        // Lowercase and bare codes are what parse_key takes, so they plan too.
+        assert_eq!(
+            plan("scripts/key.sh key_enter"),
+            Some(vec![Step::Key("key_enter".into())])
+        );
+        assert_eq!(
+            plan("scripts/key.sh 105"),
+            Some(vec![Step::Key("105".into())])
+        );
+        assert_eq!(
+            plan("scripts/key.sh page_next"),
+            Some(vec![Step::Key("page_next".into())])
+        );
+        // Unknown names stay a shell call so key.sh can still try evemu.
+        assert_eq!(plan("scripts/key.sh NOT_A_KEY"), None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,9 @@ pub struct DeviceConfig {
     pub name: Option<String>,
     pub uniq: Option<String>,
     pub grab: bool,
+    /// Whether the file said so. Blocks added by the pairing side never do, and
+    /// those are the ones the worker is allowed to downgrade to a shared open.
+    pub grab_explicit: bool,
     pub keyboard_layout: Option<String>,
     pub mappings: HashMap<Key, String>,
     pub long_press_mappings: HashMap<Key, String>,
@@ -81,6 +84,7 @@ impl DeviceConfig {
             name: None,
             uniq: None,
             grab: true,
+            grab_explicit: false,
             keyboard_layout: None,
             mappings: HashMap::new(),
             long_press_mappings: HashMap::new(),
@@ -204,7 +208,10 @@ impl Config {
                 None => {
                     if let Some(v) = get(entries, "name") { dev.name = Some(v.to_string()); }
                     if let Some(v) = get(entries, "uniq") { dev.uniq = Some(v.to_string()); }
-                    if let Some(v) = get(entries, "grab") { dev.grab = parse_bool(v); }
+                    if let Some(v) = get(entries, "grab") {
+                        dev.grab = parse_bool(v);
+                        dev.grab_explicit = true;
+                    }
                     dev.keyboard_layout = get(entries, "keyboard_layout")
                         .map(str::trim)
                         .filter(|v| !v.is_empty())
@@ -342,6 +349,20 @@ mod tests {
         assert!(dev.dpad_mappings[&DpadDirection::Left].ends_with("key.sh KEY_LEFT"));
         assert!(dev.mappings[&Key::new(304)].ends_with("key.sh KEY_ENTER"));
         assert!(dev.mappings[&Key::new(311)].ends_with("key.sh page_next"));
+    }
+
+    #[test]
+    fn grab_is_only_explicit_when_the_file_says_so() {
+        // The worker downgrades an implicit grab on anything that isn't a
+        // gamepad, so the difference has to survive the parse.
+        let cfg = load_str(
+            "kbm-grab.ini",
+            "[device.pad]\nuniq = AA:BB:CC:DD:EE:FF\n\n[device.kbd]\nuniq = 11:22:33:44:55:66\ngrab = true\n",
+        );
+        let pad = cfg.devices.iter().find(|d| d.id == "pad").expect("pad");
+        assert!(pad.grab && !pad.grab_explicit);
+        let kbd = cfg.devices.iter().find(|d| d.id == "kbd").expect("kbd");
+        assert!(kbd.grab && kbd.grab_explicit);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use configparser::ini::Ini;
 use evdev::Key;
+use log::info;
 use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
@@ -35,7 +36,45 @@ pub struct DeviceConfig {
     pub trigger_longpress_mappings: HashMap<Trigger, String>,
 }
 
+const KEY_SH: &str = "/mnt/us/kindle-button-mapper/scripts/key.sh";
+
 impl DeviceConfig {
+    /// The default gamepad layout, arrows on the D-pad, Enter/Back on A and B,
+    /// page turns on the shoulders. The worker applies it when an unmapped
+    /// device turns out to be a gamepad, so a pad added through the app drives
+    /// KOReader before anyone maps a button. Config load can't decide this,
+    /// only the opened node's capabilities say what the device is.
+    pub fn apply_default_layout(&mut self) {
+        for (dir, key) in [
+            (DpadDirection::Up, "KEY_UP"),
+            (DpadDirection::Down, "KEY_DOWN"),
+            (DpadDirection::Left, "KEY_LEFT"),
+            (DpadDirection::Right, "KEY_RIGHT"),
+        ] {
+            self.dpad_mappings.insert(dir, format!("{} {}", KEY_SH, key));
+        }
+        // BTN_A, BTN_B, BTN_TL, BTN_TR.
+        for (code, key) in [
+            (304u16, "KEY_ENTER"),
+            (305, "KEY_BACK"),
+            (310, "page_prev"),
+            (311, "page_next"),
+        ] {
+            self.mappings
+                .insert(Key::new(code), format!("{} {}", KEY_SH, key));
+        }
+        info!("[{}] no mappings configured, using the default gamepad layout", self.id);
+    }
+
+    pub fn is_unmapped(&self) -> bool {
+        self.mappings.is_empty()
+            && self.long_press_mappings.is_empty()
+            && self.dpad_mappings.is_empty()
+            && self.dpad_longpress_mappings.is_empty()
+            && self.trigger_mappings.is_empty()
+            && self.trigger_longpress_mappings.is_empty()
+    }
+
     fn new(id: String) -> Self {
         Self {
             id,
@@ -268,5 +307,52 @@ fn parse_trigger(s: &str) -> Option<Trigger> {
         "lt" | "left" => Some(Trigger::LT),
         "rt" | "right" => Some(Trigger::RT),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn load_str(name: &str, body: &str) -> Config {
+        let path = std::env::temp_dir().join(name);
+        let mut f = std::fs::File::create(&path).expect("write test config");
+        f.write_all(body.as_bytes()).expect("write test config");
+        Config::load(&path).expect("load test config")
+    }
+
+    #[test]
+    fn load_leaves_an_unmapped_device_unmapped() {
+        // The worker decides on defaults from the opened node's capabilities;
+        // load must not guess.
+        let cfg = load_str(
+            "kbm-defaults.ini",
+            "[device.pad]\nuniq = AA:BB:CC:DD:EE:FF\n",
+        );
+        assert!(cfg.devices[0].is_unmapped());
+    }
+
+    #[test]
+    fn default_layout_covers_dpad_and_face_buttons() {
+        let mut dev = DeviceConfig::new("pad".into());
+        dev.apply_default_layout();
+        assert!(!dev.is_unmapped());
+        assert_eq!(dev.dpad_mappings.len(), 4);
+        assert!(dev.dpad_mappings[&DpadDirection::Left].ends_with("key.sh KEY_LEFT"));
+        assert!(dev.mappings[&Key::new(304)].ends_with("key.sh KEY_ENTER"));
+        assert!(dev.mappings[&Key::new(311)].ends_with("key.sh page_next"));
+    }
+
+    #[test]
+    fn one_hand_mapped_button_counts_as_mapped() {
+        let cfg = load_str(
+            "kbm-nodefaults.ini",
+            "[device.pad]\nuniq = AA:BB:CC:DD:EE:FF\n\n[device.pad.buttons]\n304 = /mnt/us/mine.sh\n",
+        );
+        let dev = &cfg.devices[0];
+        assert!(!dev.is_unmapped());
+        assert!(dev.dpad_mappings.is_empty());
+        assert_eq!(dev.mappings[&Key::new(304)], "/mnt/us/mine.sh");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct DeviceConfig {
     /// Whether the file said so. Blocks added by the pairing side never do, and
     /// those are the ones the worker is allowed to downgrade to a shared open.
     pub grab_explicit: bool,
+    /// Re-emit keys with no mapping through the virtual keyboard. Only means
+    /// anything alongside a grab, and it is what makes a keyboard survive one.
+    pub passthrough: bool,
     pub keyboard_layout: Option<String>,
     pub mappings: HashMap<Key, String>,
     pub long_press_mappings: HashMap<Key, String>,
@@ -78,6 +81,11 @@ impl DeviceConfig {
             && self.trigger_longpress_mappings.is_empty()
     }
 
+    #[cfg(test)]
+    pub fn for_test(id: &str) -> Self {
+        Self::new(id.to_string())
+    }
+
     fn new(id: String) -> Self {
         Self {
             id,
@@ -85,6 +93,7 @@ impl DeviceConfig {
             uniq: None,
             grab: true,
             grab_explicit: false,
+            passthrough: false,
             keyboard_layout: None,
             mappings: HashMap::new(),
             long_press_mappings: HashMap::new(),
@@ -212,6 +221,7 @@ impl Config {
                         dev.grab = parse_bool(v);
                         dev.grab_explicit = true;
                     }
+                    if let Some(v) = get(entries, "passthrough") { dev.passthrough = parse_bool(v); }
                     dev.keyboard_layout = get(entries, "keyboard_layout")
                         .map(str::trim)
                         .filter(|v| !v.is_empty())
@@ -363,6 +373,18 @@ mod tests {
         assert!(pad.grab && !pad.grab_explicit);
         let kbd = cfg.devices.iter().find(|d| d.id == "kbd").expect("kbd");
         assert!(kbd.grab && kbd.grab_explicit);
+    }
+
+    #[test]
+    fn passthrough_is_off_unless_asked_for() {
+        let cfg = load_str(
+            "kbm-passthrough.ini",
+            "[device.pad]\nuniq = AA:BB:CC:DD:EE:FF\n\n[device.kbd]\nuniq = 11:22:33:44:55:66\ngrab = true\npassthrough = true\n",
+        );
+        let pad = cfg.devices.iter().find(|d| d.id == "pad").expect("pad");
+        assert!(!pad.passthrough);
+        let kbd = cfg.devices.iter().find(|d| d.id == "kbd").expect("kbd");
+        assert!(kbd.passthrough && kbd.grab && kbd.grab_explicit);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,8 @@ use std::thread;
 use std::time::Duration;
 
 const INPUT_DIR: &str = "/dev/input";
+const SETTLE_ATTEMPTS: u32 = 20;
+const SETTLE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// A Bluetooth node's uniq carries the address type as a suffix
 /// ("E0:F6:B5:BC:1C:7F/P"), but configs hold the bare MAC in whatever case
@@ -116,28 +118,27 @@ impl InputHandler {
             let events = inotify.read_events()
                 .map_err(|e| format!("inotify read failed: {}", e))?;
 
-            for event in events {
-                if let Some(event_name) = &event.name {
-                    let name_str = event_name.to_string_lossy();
-                    if !name_str.starts_with("event") {
-                        continue;
-                    }
-                    let path = Path::new(INPUT_DIR).join(&*name_str);
-                    thread::sleep(Duration::from_millis(100));
+            let new_node = events.iter().any(|e| {
+                e.name.as_ref().is_some_and(|n| n.to_string_lossy().starts_with("event"))
+            });
+            if !new_node {
+                continue;
+            }
 
-                    match Device::open(&path) {
-                        Ok(dev) => {
-                            if self.matches_device(&dev) {
-                                info!("Found device at {}", path.display());
-                                return Ok(dev);
-                            }
-                        }
-                        Err(e) => {
-                            debug!("Cannot open new device {}: {}", path.display(), e);
-                        }
-                    }
+            // A node is not usable the instant it appears: udev still has to
+            // apply permissions, and a uhid node's uniq is filled in after
+            // the node shows up. Probing once right after the event loses
+            // that race often enough to matter, and since the event is
+            // consumed the device would then be ignored until it connects
+            // again, which is why it took a power cycle to come good. Rescan
+            // over a short window instead of trusting a single probe.
+            for _ in 0..SETTLE_ATTEMPTS {
+                thread::sleep(SETTLE_INTERVAL);
+                if let Some(dev) = self.scan_for_device()? {
+                    return Ok(dev);
                 }
             }
+            debug!("New input node did not match within the settle window");
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -38,7 +38,7 @@ impl InputHandler {
         }
     }
 
-    pub fn open(&self) -> Result<Device, String> {
+    pub fn open(&self) -> Result<(Device, bool), String> {
         let has_identity = self.device_uniq.as_deref().is_some_and(|u| !u.is_empty())
             || self.device_name.as_deref().is_some_and(|n| !n.is_empty());
         if !has_identity {
@@ -142,13 +142,20 @@ impl InputHandler {
         }
     }
 
-    fn finish_open(&self, mut device: Device) -> Result<Device, String> {
+    /// The device, and whether the exclusive grab was actually taken. A failed
+    /// grab is not fatal, but the caller has to know: whoever holds it still
+    /// gets the events, so anything that assumes exclusivity would double up.
+    fn finish_open(&self, mut device: Device) -> Result<(Device, bool), String> {
         if device.name().unwrap_or("") == "kindle-button-mapper" {
             return Err("Refusing to read our own virtual keyboard".to_string());
         }
+        let mut grabbed = false;
         if self.grab {
             match device.grab() {
-                Ok(()) => info!("Grabbed device exclusively"),
+                Ok(()) => {
+                    grabbed = true;
+                    info!("Grabbed device exclusively");
+                }
                 Err(e) => warn!("Cannot grab device: {}, continuing without exclusive access", e),
             }
         } else {
@@ -157,7 +164,7 @@ impl InputHandler {
         info!("Reading events from {} (uniq={:?})",
             device.name().unwrap_or("?"),
             device.unique_name().unwrap_or(""));
-        Ok(device)
+        Ok((device, grabbed))
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,14 @@ use std::time::Duration;
 
 const INPUT_DIR: &str = "/dev/input";
 
+/// A Bluetooth node's uniq carries the address type as a suffix
+/// ("E0:F6:B5:BC:1C:7F/P"), but configs hold the bare MAC in whatever case
+/// the user typed. Compare only the address part, case-insensitively.
+pub fn uniq_matches(node: &str, want: &str) -> bool {
+    let bare = |s: &str| s.split('/').next().unwrap_or("").to_ascii_uppercase();
+    !want.is_empty() && bare(node) == bare(want)
+}
+
 pub struct InputHandler {
     device_name: Option<String>,
     device_uniq: Option<String>,
@@ -52,7 +60,7 @@ impl InputHandler {
         // alone when set, so the device name is just a label.
         if let Some(ref uniq) = self.device_uniq {
             if !uniq.is_empty() {
-                return dev.unique_name().unwrap_or("") == uniq.as_str();
+                return uniq_matches(dev.unique_name().unwrap_or(""), uniq);
             }
         }
         if let Some(ref name) = self.device_name {
@@ -149,5 +157,20 @@ impl InputHandler {
             device.name().unwrap_or("?"),
             device.unique_name().unwrap_or(""));
         Ok(device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uniq_matches;
+
+    #[test]
+    fn uniq_ignores_suffix_and_case() {
+        assert!(uniq_matches("E0:F6:B5:BC:1C:7F/P", "E0:F6:B5:BC:1C:7F"));
+        assert!(uniq_matches("E0:F6:B5:BC:1C:7F/P", "e0:f6:b5:bc:1c:7f"));
+        assert!(uniq_matches("E0:F6:B5:BC:1C:7F", "E0:F6:B5:BC:1C:7F/P"));
+        assert!(!uniq_matches("E0:F6:B5:BC:1C:7F/P", "AA:BB:CC:DD:EE:FF"));
+        assert!(!uniq_matches("", "AA:BB:CC:DD:EE:FF"));
+        assert!(!uniq_matches("E0:F6:B5:BC:1C:7F/P", ""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,16 +94,6 @@ fn main() {
     }
 
     reload::publish(&config);
-    {
-        let path = config_path.to_string();
-        thread::Builder::new()
-            .name("reload".into())
-            .spawn(move || loop {
-                reload::poll(&path);
-                thread::sleep(Duration::from_millis(200));
-            })
-            .expect("spawn reload thread");
-    }
 
     // Virtual keyboard via uinput — kept alive for the daemon's lifetime by the
     // FIFO thread, which injects the keys scripts/key.sh asks for. Page turns
@@ -119,7 +109,6 @@ fn main() {
         .filter(|l| !l.is_empty())
         .and_then(LayoutOverride::new);
 
-    let mut handles = Vec::new();
     let settings = WorkerSettings {
         debounce_ms: config.debounce_ms,
         long_press_ms: config.long_press_ms,
@@ -130,24 +119,29 @@ fn main() {
         on_disconnect: config.on_disconnect.clone(),
     };
     for device in config.devices {
-        let id = device.id.clone();
-        let settings = settings.clone();
-        let h = thread::Builder::new()
-            .name(format!("dev:{}", id))
-            .spawn(move || device_worker(device, settings))
-            .expect("spawn device thread");
-        handles.push(h);
-    }
-
-    if handles.is_empty() {
-        info!("No devices configured — idling. Add a device via the Button Mapper WAF app and restart.");
-        loop {
-            thread::sleep(Duration::from_secs(60));
+        if reload::claim(&device.id) {
+            spawn_worker(device, settings.clone());
         }
     }
-    for h in handles {
-        let _ = h.join();
+
+    // Reload thread doubles as the supervisor: a device added to the config
+    // since startup gets its worker here rather than waiting for a restart.
+    let path = config_path.to_string();
+    loop {
+        for device in reload::poll(&path) {
+            info!("[{}] new in the config, starting a worker", device.id);
+            spawn_worker(device, settings.clone());
+        }
+        thread::sleep(Duration::from_millis(200));
     }
+}
+
+fn spawn_worker(device: config::DeviceConfig, settings: WorkerSettings) {
+    let id = device.id.clone();
+    thread::Builder::new()
+        .name(format!("dev:{}", id))
+        .spawn(move || device_worker(device, settings))
+        .expect("spawn device thread");
 }
 
 #[derive(Clone)]
@@ -161,61 +155,104 @@ struct WorkerSettings {
     on_disconnect: Option<String>,
 }
 
+/// Why the event loop gave the device back.
+enum Exit {
+    Disconnected(String),
+    /// The config no longer lists this device, so stop touching its node.
+    Removed,
+}
+
+const PARK_POLL: Duration = Duration::from_millis(500);
+
+/// Sit out until a reload says something about this device changed. Parking
+/// rather than returning matters because a worker only ever holds a node it
+/// should be holding, and an exiting one would leave the id claimed forever.
+fn park_until_reconfigured(id: &str, generation: &mut u64) -> config::DeviceConfig {
+    loop {
+        thread::sleep(PARK_POLL);
+        let current = reload::generation();
+        if current == *generation {
+            continue;
+        }
+        *generation = current;
+        if let Some(cfg) = reload::device_config(id) {
+            info!("[{}] config changed, picking the device back up", id);
+            return cfg;
+        }
+    }
+}
+
 fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
-    let mut mapper = Mapper::new(
-        &cfg,
-        settings.debounce_ms,
-        settings.long_press_ms,
-        settings.repeat_ms,
-        settings.log_buttons,
-    );
-    let mut checked_defaults = false;
+    let build = |cfg: &config::DeviceConfig| {
+        Mapper::new(
+            cfg,
+            settings.debounce_ms,
+            settings.long_press_ms,
+            settings.repeat_ms,
+            settings.log_buttons,
+        )
+    };
+    let mut mapper = build(&cfg);
     let mut generation = reload::generation();
 
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
         match handler.open() {
             Ok(mut device) => {
-                // An unmapped device only gets the default gamepad layout if
-                // the node says it is one; the config alone can't tell a pad
-                // from a keyboard, and grabbing an unmapped keyboard would
-                // kill it for the whole system.
-                if !checked_defaults && cfg.is_unmapped() {
-                    checked_defaults = true;
-                    if is_gamepad(&device) {
+                // Only the opened node says whether this is a pad or a
+                // keyboard, and the two want opposite treatment.
+                let gamepad = is_gamepad(&device);
+                if cfg.is_unmapped() {
+                    if gamepad {
                         cfg.apply_default_layout();
-                        mapper = Mapper::new(
-                            &cfg,
-                            settings.debounce_ms,
-                            settings.long_press_ms,
-                            settings.repeat_ms,
-                            settings.log_buttons,
-                        );
+                        mapper = build(&cfg);
                     } else if cfg.keyboard_layout.is_none() {
                         info!(
                             "[{}] no mappings and not a gamepad — leaving it alone until something is mapped",
                             cfg.id
                         );
-                        // Dropping the device releases the grab. Park rather
-                        // than return: a worker exiting would let main finish
-                        // and upstart cycle the daemon.
+                        // Dropping the device releases the grab.
                         drop(device);
-                        loop {
-                            thread::sleep(Duration::from_secs(3600));
-                        }
+                        cfg = park_until_reconfigured(&cfg.id, &mut generation);
+                        mapper = build(&cfg);
+                        continue;
                     }
                 }
+
+                // A keyboard is shared with the rest of the system. Holding it
+                // exclusively would swallow every key this config does not
+                // name, so downgrade to a shared open unless the file asked
+                // for the grab by hand. Pairing-written blocks never do.
+                let mut grab = cfg.grab;
+                if grab && !cfg.grab_explicit && !gamepad {
+                    match device.ungrab() {
+                        Ok(()) => {
+                            grab = false;
+                            info!("[{}] not a gamepad, sharing it instead of grabbing", cfg.id);
+                        }
+                        Err(e) => warn!("[{}] cannot release the grab: {}", cfg.id, e),
+                    }
+                }
+
                 info!("[{}] device connected", cfg.id);
                 if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab,
-                    settings.keep_awake, &cfg, &mut generation, &settings) {
-                    error!("[{}] event loop error: {}", cfg.id, e);
-                    if let Some(ref script) = settings.on_disconnect {
-                        info!("[{}] device disconnected, running on_disconnect script", cfg.id);
-                        execute_script(script);
+                match run_event_loop(&mut device, &mut mapper, grab,
+                    &mut cfg, &mut generation, &settings) {
+                    Exit::Removed => {
+                        drop(device);
+                        cfg = park_until_reconfigured(&cfg.id, &mut generation);
+                        mapper = build(&cfg);
+                        continue;
+                    }
+                    Exit::Disconnected(e) => {
+                        error!("[{}] event loop error: {}", cfg.id, e);
+                        if let Some(ref script) = settings.on_disconnect {
+                            info!("[{}] device disconnected, running on_disconnect script", cfg.id);
+                            execute_script(script);
+                        }
                     }
                 }
             }
@@ -232,16 +269,15 @@ fn run_event_loop(
     device: &mut evdev::Device,
     mapper: &mut Mapper,
     grab: bool,
-    keep_awake: bool,
-    cfg: &config::DeviceConfig,
+    cfg: &mut config::DeviceConfig,
     generation: &mut u64,
     settings: &WorkerSettings,
-) -> Result<(), String> {
+) -> Exit {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
     let mut grabbed = grab;
 
-    let mut last_poke: Option<Instant> = if keep_awake {
+    let mut last_poke: Option<Instant> = if settings.keep_awake {
         execute_script(KEEP_AWAKE_RELEASE);
         Some(Instant::now())
     } else {
@@ -252,15 +288,22 @@ fn run_event_loop(
         let current = reload::generation();
         if current != *generation {
             *generation = current;
-            if let Some(fresh) = reload::device_config(&cfg.id) {
-                info!("[{}] applying reloaded mappings", cfg.id);
-                *mapper = Mapper::new(
-                    &fresh,
-                    settings.debounce_ms,
-                    settings.long_press_ms,
-                    settings.repeat_ms,
-                    settings.log_buttons,
-                );
+            match reload::device_config(&cfg.id) {
+                Some(fresh) => {
+                    info!("[{}] applying reloaded mappings", cfg.id);
+                    *mapper = Mapper::new(
+                        &fresh,
+                        settings.debounce_ms,
+                        settings.long_press_ms,
+                        settings.repeat_ms,
+                        settings.log_buttons,
+                    );
+                    *cfg = fresh;
+                }
+                None => {
+                    info!("[{}] gone from the config, releasing the device", cfg.id);
+                    return Exit::Removed;
+                }
             }
         }
 
@@ -286,13 +329,13 @@ fn run_event_loop(
             Ok(0) => continue,
             Ok(_) => {}
             Err(nix::errno::Errno::EINTR) => continue,
-            Err(e) => return Err(format!("poll error: {}", e)),
+            Err(e) => return Exit::Disconnected(format!("poll error: {}", e)),
         }
 
         let events = match device.fetch_events() {
             Ok(ev) => ev,
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-            Err(e) => return Err(format!("Read error: {}", e)),
+            Err(e) => return Exit::Disconnected(format!("Read error: {}", e)),
         };
 
         if paused {
@@ -332,7 +375,7 @@ fn run_event_loop(
             }
         }
 
-        if keep_awake && activity {
+        if settings.keep_awake && activity {
             let now = Instant::now();
             if last_poke.is_none_or(|t| now.duration_since(t) >= KEEP_AWAKE_INTERVAL) {
                 info!("keep-awake: re-armed screensaver idle timer");

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,7 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
         match handler.open() {
-            Ok(mut device) => {
+            Ok((mut device, grabbed_at_open)) => {
                 // Only the opened node says whether this is a pad or a
                 // keyboard, and the two want opposite treatment.
                 let gamepad = is_gamepad(&device);
@@ -219,27 +219,53 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                     }
                 }
 
-                // A keyboard is shared with the rest of the system. Holding it
-                // exclusively would swallow every key this config does not
-                // name, so downgrade to a shared open unless the file asked
-                // for the grab by hand. Pairing-written blocks never do.
-                let mut grab = cfg.grab;
-                if grab && !cfg.grab_explicit && !gamepad {
+                // Three ways to own a device. Grabbing it exclusively is right
+                // for a pad, where an unmapped button should do nothing, and
+                // wrong for a keyboard, where it would swallow every key this
+                // config does not name. Passthrough is the middle ground: hold
+                // the device, but relay what we don't map. Nothing to guess
+                // when the file says so, otherwise decide from the node.
+                let mut grab = effective_grab(&cfg, gamepad) && grabbed_at_open;
+                if grabbed_at_open && !grab {
                     match device.ungrab() {
-                        Ok(()) => {
-                            grab = false;
-                            info!("[{}] not a gamepad, sharing it instead of grabbing", cfg.id);
+                        Ok(()) => info!("[{}] not a gamepad, sharing it instead of grabbing", cfg.id),
+                        Err(e) => {
+                            warn!("[{}] cannot release the grab: {}", cfg.id, e);
+                            grab = true;
                         }
-                        Err(e) => warn!("[{}] cannot release the grab: {}", cfg.id, e),
                     }
                 }
+                // Relaying keys we do not hold would deliver every keystroke
+                // twice, once from us and once from whoever does hold it.
+                if cfg.passthrough && !grab {
+                    warn!(
+                        "[{}] passthrough needs the exclusive grab and something else has it, relaying is off",
+                        cfg.id
+                    );
+                    cfg.passthrough = false;
+                    mapper = build(&cfg);
+                }
+                if grab && cfg.passthrough && !vkeyboard::available() {
+                    warn!(
+                        "[{}] passthrough is on but there is no uinput keyboard, unmapped keys will be lost",
+                        cfg.id
+                    );
+                }
 
-                info!("[{}] device connected", cfg.id);
+                info!(
+                    "[{}] device connected ({})",
+                    cfg.id,
+                    match (grab, cfg.passthrough) {
+                        (false, _) => "shared",
+                        (true, true) => "exclusive, unmapped keys passed through",
+                        (true, false) => "exclusive",
+                    }
+                );
                 if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                match run_event_loop(&mut device, &mut mapper, grab,
+                match run_event_loop(&mut device, &mut mapper, grab, gamepad,
                     &mut cfg, &mut generation, &settings) {
                     Exit::Removed => {
                         drop(device);
@@ -269,12 +295,14 @@ fn run_event_loop(
     device: &mut evdev::Device,
     mapper: &mut Mapper,
     grab: bool,
+    gamepad: bool,
     cfg: &mut config::DeviceConfig,
     generation: &mut u64,
     settings: &WorkerSettings,
 ) -> Exit {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
+    let mut grab = grab;
     let mut grabbed = grab;
 
     let mut last_poke: Option<Instant> = if settings.keep_awake {
@@ -298,6 +326,21 @@ fn run_event_loop(
                         settings.repeat_ms,
                         settings.log_buttons,
                     );
+                    // Switching who owns the device has to bite now rather
+                    // than on the next reconnect, or the toggle looks broken.
+                    let want = effective_grab(&fresh, gamepad);
+                    if want != grab {
+                        let changed = if want { device.grab() } else { device.ungrab() };
+                        match changed {
+                            Ok(()) => {
+                                grab = want;
+                                grabbed = want;
+                                info!("[{}] now {}", cfg.id,
+                                    if want { "holding the device" } else { "sharing the device" });
+                            }
+                            Err(e) => warn!("[{}] cannot change who holds the device: {}", cfg.id, e),
+                        }
+                    }
                     *cfg = fresh;
                 }
                 None => {
@@ -384,6 +427,13 @@ fn run_event_loop(
             }
         }
     }
+}
+
+/// Whether the daemon should hold this device exclusively. An explicit `grab`
+/// in the file is taken at its word; without one only a gamepad is claimed,
+/// since grabbing a keyboard would swallow every key nothing maps.
+fn effective_grab(cfg: &config::DeviceConfig, gamepad: bool) -> bool {
+    cfg.grab && (cfg.grab_explicit || gamepad)
 }
 
 fn is_gamepad(dev: &evdev::Device) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod koreader;
 mod layout;
 mod mapper;
 mod pause;
+mod reload;
 mod vkeyboard;
 mod waf_helper;
 
@@ -87,6 +88,21 @@ fn main() {
     unsafe {
         signal(Signal::SIGINT, SigHandler::Handler(handle_signal)).ok();
         signal(Signal::SIGTERM, SigHandler::Handler(handle_signal)).ok();
+        // The WAF helper sends this instead of restarting us, so the uinput
+        // keyboard survives a mapping edit.
+        signal(Signal::SIGHUP, SigHandler::Handler(reload::handle_sighup)).ok();
+    }
+
+    reload::publish(&config);
+    {
+        let path = config_path.to_string();
+        thread::Builder::new()
+            .name("reload".into())
+            .spawn(move || loop {
+                reload::poll(&path);
+                thread::sleep(Duration::from_millis(200));
+            })
+            .expect("spawn reload thread");
     }
 
     // Virtual keyboard via uinput — kept alive for the daemon's lifetime by the
@@ -154,6 +170,7 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
         settings.log_buttons,
     );
     let mut checked_defaults = false;
+    let mut generation = reload::generation();
 
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
@@ -193,7 +210,8 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);
                 }
-                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab, settings.keep_awake) {
+                if let Err(e) = run_event_loop(&mut device, &mut mapper, cfg.grab,
+                    settings.keep_awake, &cfg, &mut generation, &settings) {
                     error!("[{}] event loop error: {}", cfg.id, e);
                     if let Some(ref script) = settings.on_disconnect {
                         info!("[{}] device disconnected, running on_disconnect script", cfg.id);
@@ -210,7 +228,15 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
     }
 }
 
-fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, keep_awake: bool) -> Result<(), String> {
+fn run_event_loop(
+    device: &mut evdev::Device,
+    mapper: &mut Mapper,
+    grab: bool,
+    keep_awake: bool,
+    cfg: &config::DeviceConfig,
+    generation: &mut u64,
+    settings: &WorkerSettings,
+) -> Result<(), String> {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
     let mut grabbed = grab;
@@ -223,6 +249,21 @@ fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, k
     };
 
     loop {
+        let current = reload::generation();
+        if current != *generation {
+            *generation = current;
+            if let Some(fresh) = reload::device_config(&cfg.id) {
+                info!("[{}] applying reloaded mappings", cfg.id);
+                *mapper = Mapper::new(
+                    &fresh,
+                    settings.debounce_ms,
+                    settings.long_press_ms,
+                    settings.repeat_ms,
+                    settings.log_buttons,
+                );
+            }
+        }
+
         // Release the grab while capture is paused, restore it after.
         let paused = pause::active();
         if paused && grabbed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ struct WorkerSettings {
     on_disconnect: Option<String>,
 }
 
-fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
+fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
     let mut mapper = Mapper::new(
         &cfg,
         settings.debounce_ms,
@@ -153,11 +153,41 @@ fn device_worker(cfg: config::DeviceConfig, settings: WorkerSettings) {
         settings.repeat_ms,
         settings.log_buttons,
     );
+    let mut checked_defaults = false;
 
     loop {
         let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
         match handler.open() {
             Ok(mut device) => {
+                // An unmapped device only gets the default gamepad layout if
+                // the node says it is one; the config alone can't tell a pad
+                // from a keyboard, and grabbing an unmapped keyboard would
+                // kill it for the whole system.
+                if !checked_defaults && cfg.is_unmapped() {
+                    checked_defaults = true;
+                    if is_gamepad(&device) {
+                        cfg.apply_default_layout();
+                        mapper = Mapper::new(
+                            &cfg,
+                            settings.debounce_ms,
+                            settings.long_press_ms,
+                            settings.repeat_ms,
+                            settings.log_buttons,
+                        );
+                    } else if cfg.keyboard_layout.is_none() {
+                        info!(
+                            "[{}] no mappings and not a gamepad — leaving it alone until something is mapped",
+                            cfg.id
+                        );
+                        // Dropping the device releases the grab. Park rather
+                        // than return: a worker exiting would let main finish
+                        // and upstart cycle the daemon.
+                        drop(device);
+                        loop {
+                            thread::sleep(Duration::from_secs(3600));
+                        }
+                    }
+                }
                 info!("[{}] device connected", cfg.id);
                 if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
@@ -270,6 +300,14 @@ fn run_event_loop(device: &mut evdev::Device, mapper: &mut Mapper, grab: bool, k
             }
         }
     }
+}
+
+fn is_gamepad(dev: &evdev::Device) -> bool {
+    dev.supported_keys()
+        .is_some_and(|k| k.contains(evdev::Key::BTN_SOUTH))
+        || dev
+            .supported_absolute_axes()
+            .is_some_and(|a| a.contains(evdev::AbsoluteAxisType::ABS_HAT0X))
 }
 
 fn set_nonblocking(fd: std::os::unix::io::RawFd) {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,5 +1,6 @@
 use crate::action;
 use crate::config::{DeviceConfig, DpadDirection, Trigger};
+use crate::vkeyboard;
 use evdev::Key;
 use log::{debug, info};
 use std::collections::HashMap;
@@ -16,6 +17,7 @@ pub struct Mapper {
     long_press_ms: u64,
     repeat_ms: u64,
     log_buttons: bool,
+    passthrough: bool,
     last_press: HashMap<Key, Instant>,
     press_start: HashMap<Key, Instant>,
     long_press_fired: HashMap<Key, bool>,
@@ -53,6 +55,7 @@ impl Mapper {
             long_press_ms,
             repeat_ms,
             log_buttons,
+            passthrough: cfg.passthrough,
             last_press: HashMap::new(),
             press_start: HashMap::new(),
             long_press_fired: HashMap::new(),
@@ -70,7 +73,29 @@ impl Mapper {
         }
     }
 
+    /// Whether this key belongs to the mapper. Anything else is the device's
+    /// own, and in passthrough mode it has to keep working.
+    fn claims(&self, key: Key) -> bool {
+        self.mappings.contains_key(&key) || self.long_press_mappings.contains_key(&key)
+    }
+
+    /// Relay a key the mapper grabbed but does not want. Debounce and the
+    /// press bookkeeping are for firing actions, a relayed keystroke is
+    /// passed on exactly as it arrived.
+    fn relay(&self, key: Key, value: i32) -> bool {
+        if !self.passthrough || self.claims(key) {
+            return false;
+        }
+        if !vkeyboard::forward(key.code(), value) {
+            debug!("Passthrough dropped {:?}, no virtual keyboard", key);
+        }
+        true
+    }
+
     pub fn handle_press(&mut self, key: Key) {
+        if self.relay(key, 1) {
+            return;
+        }
         // Debounce check
         if let Some(last) = self.last_press.get(&key) {
             if last.elapsed() < Duration::from_millis(self.debounce_ms) {
@@ -102,6 +127,9 @@ impl Mapper {
     }
 
     pub fn handle_held(&mut self, key: Key) {
+        if self.relay(key, 2) {
+            return;
+        }
         // Check if we've started long press mode
         let long_press_active = self.long_press_fired.get(&key).copied().unwrap_or(false);
 
@@ -146,6 +174,9 @@ impl Mapper {
     }
 
     pub fn handle_release(&mut self, key: Key) {
+        if self.relay(key, 0) {
+            return;
+        }
         // A debounced press never registers in press_start, so its release
         // must not fire the action either.
         let had_press = self.press_start.remove(&key).is_some();
@@ -375,4 +406,44 @@ impl Mapper {
 
 fn execute_script(script: &str) {
     action::run(script);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DeviceConfig;
+
+    fn mapper(passthrough: bool, mapped: &[u16]) -> Mapper {
+        let mut cfg = DeviceConfig::for_test("dev");
+        cfg.passthrough = passthrough;
+        for code in mapped {
+            cfg.mappings.insert(Key::new(*code), "/bin/true".into());
+        }
+        Mapper::new(&cfg, 0, 500, 100, false)
+    }
+
+    #[test]
+    fn passthrough_relays_only_what_is_not_mapped() {
+        let m = mapper(true, &[30]);
+        // Mapped, so the mapper runs the action rather than relaying the key.
+        assert!(!m.relay(Key::new(30), 1));
+        // Not mapped, so it has to keep typing.
+        assert!(m.relay(Key::new(31), 1));
+    }
+
+    #[test]
+    fn without_passthrough_nothing_is_relayed() {
+        let m = mapper(false, &[30]);
+        assert!(!m.relay(Key::new(30), 1));
+        assert!(!m.relay(Key::new(31), 1));
+    }
+
+    #[test]
+    fn a_long_press_mapping_also_claims_the_key() {
+        let mut cfg = DeviceConfig::for_test("dev");
+        cfg.passthrough = true;
+        cfg.long_press_mappings.insert(Key::new(30), "/bin/true".into());
+        let m = Mapper::new(&cfg, 0, 500, 100, false);
+        assert!(!m.relay(Key::new(30), 1));
+    }
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1,0 +1,78 @@
+//! In-process config reload.
+//!
+//! Restarting the daemon to pick up a config change destroys the uinput
+//! keyboard, and anything holding that node open sees the device disappear.
+//! KOReader reacts to that by rebuilding its UI, which throws the user out of
+//! whatever menu they were editing the mapping from. So SIGHUP re-reads the
+//! config in place instead, and the uinput node outlives it.
+
+use crate::config::{Config, DeviceConfig};
+use log::{info, warn};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+static REQUESTED: AtomicBool = AtomicBool::new(false);
+/// Bumped once per applied reload. Workers compare against their own copy.
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+static DEVICES: OnceLock<Mutex<Vec<DeviceConfig>>> = OnceLock::new();
+
+fn devices() -> &'static Mutex<Vec<DeviceConfig>> {
+    DEVICES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Signal handler. Only an atomic store, which is async-signal-safe.
+pub extern "C" fn handle_sighup(_: i32) {
+    REQUESTED.store(true, Ordering::SeqCst);
+}
+
+pub fn generation() -> u64 {
+    GENERATION.load(Ordering::SeqCst)
+}
+
+pub fn publish(config: &Config) {
+    *devices().lock().unwrap_or_else(|p| p.into_inner()) = config.devices.clone();
+}
+
+/// The device's current config, or None if it was removed from the file.
+pub fn device_config(id: &str) -> Option<DeviceConfig> {
+    devices()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .iter()
+        .find(|d| d.id == id)
+        .cloned()
+}
+
+/// Re-read the config if SIGHUP asked for it. True when a reload was applied.
+///
+/// Devices added to the file since startup have no worker and are not picked
+/// up here, that still needs a restart, but a mapping change on a device that
+/// already has one applies immediately.
+pub fn poll(config_path: &str) -> bool {
+    if !REQUESTED.swap(false, Ordering::SeqCst) {
+        return false;
+    }
+    match Config::load(config_path) {
+        Ok(new) => {
+            let known: Vec<String> = devices()
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .iter()
+                .map(|d| d.id.clone())
+                .collect();
+            for d in &new.devices {
+                if !known.contains(&d.id) {
+                    warn!("[{}] new device in config, needs a restart to be watched", d.id);
+                }
+            }
+            publish(&new);
+            let gen = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+            info!("Config reloaded in place (generation {})", gen);
+            true
+        }
+        Err(e) => {
+            warn!("Reload failed, keeping the running config: {}", e);
+            false
+        }
+    }
+}

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -8,6 +8,7 @@
 
 use crate::config::{Config, DeviceConfig};
 use log::{info, warn};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
@@ -15,9 +16,24 @@ static REQUESTED: AtomicBool = AtomicBool::new(false);
 /// Bumped once per applied reload. Workers compare against their own copy.
 static GENERATION: AtomicU64 = AtomicU64::new(0);
 static DEVICES: OnceLock<Mutex<Vec<DeviceConfig>>> = OnceLock::new();
+/// Device ids that already have a worker. Only grows, so a device removed and
+/// re-added does not end up with two threads fighting over the same node.
+static WATCHED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 fn devices() -> &'static Mutex<Vec<DeviceConfig>> {
     DEVICES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn watched() -> &'static Mutex<HashSet<String>> {
+    WATCHED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Claim a device id for a worker. False when someone already has it.
+pub fn claim(id: &str) -> bool {
+    watched()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(id.to_string())
 }
 
 /// Signal handler. Only an atomic store, which is async-signal-safe.
@@ -43,36 +59,33 @@ pub fn device_config(id: &str) -> Option<DeviceConfig> {
         .cloned()
 }
 
-/// Re-read the config if SIGHUP asked for it. True when a reload was applied.
+/// Re-read the config if SIGHUP asked for it, and hand back the devices that
+/// nobody is watching yet so the caller can start a worker for each.
 ///
-/// Devices added to the file since startup have no worker and are not picked
-/// up here, that still needs a restart, but a mapping change on a device that
-/// already has one applies immediately.
-pub fn poll(config_path: &str) -> bool {
+/// Pairing writes a new `[device.X]` block and then asks for this, so adding a
+/// device no longer needs a restart. That matters beyond convenience: a restart
+/// destroys the uinput keyboard, and KOReader stops delivering keys from a node
+/// that disappears under it until it is itself restarted.
+pub fn poll(config_path: &str) -> Vec<DeviceConfig> {
     if !REQUESTED.swap(false, Ordering::SeqCst) {
-        return false;
+        return Vec::new();
     }
     match Config::load(config_path) {
         Ok(new) => {
-            let known: Vec<String> = devices()
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
+            let fresh: Vec<DeviceConfig> = new
+                .devices
                 .iter()
-                .map(|d| d.id.clone())
+                .filter(|d| claim(&d.id))
+                .cloned()
                 .collect();
-            for d in &new.devices {
-                if !known.contains(&d.id) {
-                    warn!("[{}] new device in config, needs a restart to be watched", d.id);
-                }
-            }
             publish(&new);
             let gen = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
             info!("Config reloaded in place (generation {})", gen);
-            true
+            fresh
         }
         Err(e) => {
             warn!("Reload failed, keeping the running config: {}", e);
-            false
+            Vec::new()
         }
     }
 }

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -114,6 +114,36 @@ pub fn inject(request: &str) -> bool {
     true
 }
 
+/// Whether there is a uinput keyboard to emit into at all. Passthrough is a
+/// promise the daemon cannot keep without one.
+pub fn available() -> bool {
+    INJECTOR
+        .get()
+        .map(|i| i.lock().unwrap_or_else(|p| p.into_inner()).dev.is_some())
+        .unwrap_or(false)
+}
+
+/// Re-emit a key the mapper grabbed but has no mapping for, so a device the
+/// mapper owns exclusively still types. `value` is evdev's own: 1 press,
+/// 0 release, 2 repeat. False means there is no uinput keyboard to emit into,
+/// in which case the key is simply lost and the caller should say so.
+pub fn forward(code: u16, value: i32) -> bool {
+    let Some(injector) = INJECTOR.get() else {
+        return false;
+    };
+    let mut injector = injector.lock().unwrap_or_else(|p| p.into_inner());
+    let Some(ref mut dev) = injector.dev else {
+        return false;
+    };
+    if let Err(e) = write_event(dev, EV_KEY, code, value)
+        .and_then(|()| write_event(dev, EV_SYN, SYN_REPORT, 0))
+    {
+        warn!("Forwarding key {} failed: {}", code, e);
+        return false;
+    }
+    true
+}
+
 /// Serve key injection requests on a FIFO, one key name (or code) per line.
 ///
 /// scripts/key.sh writes to it, so nothing on the device needs an external

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -488,7 +490,26 @@ fn run_initctl(action: &str) -> (u16, String) {
     }
 }
 
+/// SIGHUP rather than a restart: restarting drops the uinput keyboard, and
+/// anything holding that node open (KOReader) sees its input device vanish and
+/// rebuilds its UI, throwing the user out of the menu they were editing from.
+/// Falls back to a restart for a daemon too old to handle the signal.
 fn reload_daemon() -> (u16, String) {
+    let (running, pid) = daemon_status();
+    if running && pid > 0 {
+        let target = Pid::from_raw(pid as i32);
+        match kill(target, Signal::SIGHUP) {
+            Ok(()) => {
+                info!("Asked the daemon to reload its config in place");
+                return (200, json_ok());
+            }
+            Err(e) => warn!("SIGHUP to {} failed: {}, restarting instead", pid, e),
+        }
+    }
+    restart_daemon()
+}
+
+fn restart_daemon() -> (u16, String) {
     run_initctl("restart")
 }
 


### PR DESCRIPTION
Groundwork for kindle-hid's KOReader plugin using the mapper as its backend instead of growing a second mapping layer inside KOReader.

A pad paired through kindle-hid shows up, you add it, and then it does nothing until every button is mapped by hand. That reads as broken hardware. A device with no mappings now gets a default layout when the opened node says it is a gamepad (BTN_SOUTH or hat axes), arrows on the D-pad, Enter and Back on A and B, page turns on the shoulders, enough to drive KOReader immediately.

The decision lives in the worker at open time, not config load, because only the node's capabilities say what the device is. An unmapped non-gamepad is released and parked, grabbing a keyboard we translate nothing for would kill it for the whole system. Mapping anything by hand, anywhere on the device, turns the defaults off, so no existing config changes behaviour.

The uniq match also compares bare MACs now. A uhid node's uniq carries the address type suffix (`E0:F6:B5:BC:1C:7F/P`) while configs hold whatever the user typed, and the exact comparison silently never matched those.

`key.sh` also stopped being a shell call. It writes the key name to the daemon's FIFO, which the daemon then hands to the same `inject()` the action thread can call directly, so the fork and the round trip bought nothing. Unknown names still fall through to the shell so `key.sh` keeps its evemu fallback for older setups.

## Testing

`cargo test` 7 passing, clippy clean, armv7 musl builds.

Tested on my Basic 5 with synthesized uinput devices matched by name.
- Fake gamepad (BTN_A/B/TL/TR + hat axes), default layout applied from node caps, grabbed, and the vkeyboard emitted hat-up→KEY_UP, hat-left→KEY_LEFT, A→KEY_ENTER, TR→page turn.
- Fake keyboard (plain keycodes), logged `no mappings and not a gamepad — leaving it alone`, grab released, KOReader kept it.
- After hand-mapping one control, defaults off for the whole device, the mapped direction fired its action and everything else logged `[unmapped]`.