### PR TITLE
fix(waf): match and store uniq without the address-type suffix

### DIFF
--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -181,6 +181,13 @@ var MapperManager = (function() {
             .replace(/"/g, "&quot;");
     }
 
+    // A Bluetooth node's uniq carries the address type as a suffix
+    // ("E0:F6:B5:BC:1C:7F/P"); configs hold the bare MAC. Compare and store
+    // only the address part, uppercased.
+    function bareUniq(s) {
+        return String(s || "").split("/")[0].replace(/^\s+|\s+$/g, "").toUpperCase();
+    }
+
     function showMessage(text, isError) {
         var bar = getEl("messageBar");
         bar.innerHTML = escapeHtml(text);
@@ -512,14 +519,14 @@ var MapperManager = (function() {
     }
 
     function resolveDevicePath(id, cb) {
-        var uniq = getValue("device." + id, "uniq") || "";
+        var uniq = bareUniq(getValue("device." + id, "uniq") || "");
         var name = getValue("device." + id, "name") || "";
         getJSON("/devices", function(data, err) {
             if (err) { cb(null, "Devices: " + err); return; }
             var list = data.devices || [];
             var match = null;
             for (var i = 0; i < list.length; i++) {
-                if (uniq && list[i].uniq === uniq) {
+                if (uniq && bareUniq(list[i].uniq || "") === uniq) {
                     match = list[i];
                     break;
                 }
@@ -894,7 +901,7 @@ var MapperManager = (function() {
             showMessage("Name needs at least one letter or digit", true);
             return;
         }
-        var uniq = (getEl("devDetailUniq").value || "").replace(/^\s+|\s+$/g, "");
+        var uniq = bareUniq(getEl("devDetailUniq").value);
         if (!uniq && !name) {
             showMessage("Set a name or MAC", true);
             return;


### PR DESCRIPTION
The evdev node's uniq carries the address type as a suffix, so a node shows up as `8A:76:5A:2F:36:23/P` while config.ini holds the bare MAC. The app compared the two with `===`, so tapping Capture said the device was not connected even with it sitting right there connected.

The Rust matcher already handles this since #37 with `uniq_matches`, this just teaches the app the same trick and normalises on save, so the two things that write a uniq into config.ini agree on the bare form. Before this, adding a device from the scan list stored it with the suffix and typing one by hand stored it without, in whatever case you typed.

Found while digging into zampierilucas/kindle-hid-passthrough#172 and #171. Worth noting the Rust half is on master but not in a release yet, and hid-passthrough bundles the release tarball, so users are still on v1.4.1 with the old exact compare.

`cargo test` passes, 13 tests.
