### PR TITLE
Rotate tap page turns so they land in landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ writes the events itself, no daemon involved. Only reach for these if the plain
 page turn does nothing, since a tap follows whatever tap zones you have set in
 the reader.
 
+The panel never turns with the screen, so a tap for the right edge of a
+landscape page has to be rotated back into panel coordinates. `tap.sh` asks the
+framework which way up it is and does that itself. KOReader rotates in software
+and tells nobody, so there it reads as upright and the tap lands where it did in
+portrait — use its HTTP Inspector, which turns the page whatever the rotation.
+Set `TAP_ROTATION` to `0`, `90`, `180` or `270` to force the angle.
+
 Everything else goes over `lipc`.
 
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.

--- a/scripts/tap.sh
+++ b/scripts/tap.sh
@@ -6,6 +6,9 @@
 # touchscreen node, so it needs nothing but a shell. Codes the panel does not
 # support are dropped by the kernel, which is why the sequence can carry both
 # BTN_TOUCH and the pressure/contact axes and still suit either panel.
+#
+# Percentages are screen space, rotated into panel space before writing.
+# TAP_ROTATION forces the angle, TAP_DRY_RUN prints the pixel and taps nothing.
 
 X_PCT="${1:-85}"
 Y_PCT="${2:-50}"
@@ -41,6 +44,23 @@ screen_size() {
     sed -n 's/^[^:]*:\([0-9]*\)x\([0-9]*\).*/\1 \2/p' "$FB_MODES" 2>/dev/null | head -n 1
 }
 
+# KOReader rotates in software and tells nobody, so there this reads upright.
+# Wrapped because a suspended framework can hang the call.
+rotation() {
+    [ -n "$TAP_ROTATION" ] && { echo "$TAP_ROTATION"; return; }
+    if command -v timeout >/dev/null 2>&1; then
+        o=$(timeout 1 lipc-get-prop com.lab126.system orientation 2>/dev/null)
+    else
+        o=$(lipc-get-prop com.lab126.system orientation 2>/dev/null)
+    fi
+    case "$o" in
+        R) echo 90 ;;
+        D) echo 180 ;;
+        L) echo 270 ;;
+        *) echo 0 ;;
+    esac
+}
+
 DEV=$(touch_node)
 [ -z "$DEV" ] && { echo "tap.sh: no touchscreen found" >&2; exit 1; }
 
@@ -51,8 +71,22 @@ case "$W$H" in
     ""|*[!0-9]*) echo "tap.sh: cannot read screen size from $FB_MODES" >&2; exit 1 ;;
 esac
 
+ROT=$(rotation)
+case "$ROT" in
+    90)  T=$X_PCT; X_PCT=$(( 100 - Y_PCT )); Y_PCT=$T ;;
+    180) X_PCT=$(( 100 - X_PCT )); Y_PCT=$(( 100 - Y_PCT )) ;;
+    270) T=$X_PCT; X_PCT=$Y_PCT; Y_PCT=$(( 100 - T )) ;;
+esac
+
+# Some firmware swaps the reported mode with the rotation, the panel never does.
+case "$ROT" in
+    90|270) [ "$W" -gt "$H" ] && { T=$W; W=$H; H=$T; } ;;
+esac
+
 X=$(( W * X_PCT / 100 ))
 Y=$(( H * Y_PCT / 100 ))
+
+[ -n "$TAP_DRY_RUN" ] && { echo "$X $Y"; exit 0; }
 
 # Escape text rather than raw bytes, so the whole sequence goes out in one
 # write. evdev rejects a write that is not a whole number of events, and a


### PR DESCRIPTION
tap.sh writes into the touchscreen node and the panel never turns with the screen, so `next_page_tap` always poked the right edge of a portrait page. In landscape that spot is the top or bottom of what you are looking at.

It now rotates the percentages back into panel coordinates, taking the angle from `com.lab126.system orientation`. `TAP_ROTATION` forces it, `TAP_DRY_RUN` prints the pixel instead of tapping.

Untested bit, `orientation` reads back empty while KOReader holds the framework, so the "R is clockwise" mapping is a guess. Two line swap in `rotation()` if it is backwards.

KOReader rotates in software and tells nobody, so it is out of scope, HTTP Inspector already survives a rotation.

Refs zampierilucas/kindle-hid-passthrough#182