### PR TITLE
fix(waf): list the node the daemon opens first when several share a MAC

### DIFF
--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -525,6 +525,8 @@ var MapperManager = (function() {
             if (err) { cb(null, "Devices: " + err); return; }
             var list = data.devices || [];
             var match = null;
+            // The helper lists nodes sharing an address best-first, so the
+            // first match is the one the daemon opens.
             for (var i = 0; i < list.length; i++) {
                 if (uniq && bareUniq(list[i].uniq || "") === uniq) {
                     match = list[i];

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -525,8 +525,6 @@ var MapperManager = (function() {
             if (err) { cb(null, "Devices: " + err); return; }
             var list = data.devices || [];
             var match = null;
-            // The helper lists nodes sharing an address best-first, so the
-            // first match is the one the daemon opens.
             for (var i = 0; i < list.length; i++) {
                 if (uniq && bareUniq(list[i].uniq || "") === uniq) {
                     match = list[i];

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,7 +13,7 @@ const SETTLE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// A Bluetooth node's uniq carries the address type as a suffix
 /// ("E0:F6:B5:BC:1C:7F/P"), but configs hold the bare MAC in whatever case
-/// the user typed. Strip it, so only the address part is compared.
+/// the user typed. Compare only the address part, case-insensitively.
 pub fn bare_addr(s: &str) -> String {
     s.split('/').next().unwrap_or("").to_ascii_uppercase()
 }
@@ -22,9 +22,6 @@ pub fn uniq_matches(node: &str, want: &str) -> bool {
     !want.is_empty() && bare_addr(node) == bare_addr(want)
 }
 
-/// How many keys the mapper could bind on this node, ignoring the buttons a
-/// pointer reports on its own. Ranks the nodes of a device that registers
-/// several under one address.
 pub fn mappable_keys(keys: Option<&AttributeSetRef<Key>>) -> usize {
     let mouse_buttons = Key::BTN_LEFT.code()..=Key::BTN_TASK.code();
     keys.map_or(0, |keys| {

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,13 +13,19 @@ const SETTLE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// A Bluetooth node's uniq carries the address type as a suffix
 /// ("E0:F6:B5:BC:1C:7F/P"), but configs hold the bare MAC in whatever case
-/// the user typed. Compare only the address part, case-insensitively.
-pub fn uniq_matches(node: &str, want: &str) -> bool {
-    let bare = |s: &str| s.split('/').next().unwrap_or("").to_ascii_uppercase();
-    !want.is_empty() && bare(node) == bare(want)
+/// the user typed. Strip it, so only the address part is compared.
+pub fn bare_addr(s: &str) -> String {
+    s.split('/').next().unwrap_or("").to_ascii_uppercase()
 }
 
-fn mappable_keys(keys: Option<&AttributeSetRef<Key>>) -> usize {
+pub fn uniq_matches(node: &str, want: &str) -> bool {
+    !want.is_empty() && bare_addr(node) == bare_addr(want)
+}
+
+/// How many keys the mapper could bind on this node, ignoring the buttons a
+/// pointer reports on its own. Ranks the nodes of a device that registers
+/// several under one address.
+pub fn mappable_keys(keys: Option<&AttributeSetRef<Key>>) -> usize {
     let mouse_buttons = Key::BTN_LEFT.code()..=Key::BTN_TASK.code();
     keys.map_or(0, |keys| {
         keys.iter().filter(|k| !mouse_buttons.contains(&k.code())).count()

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -5,6 +5,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
 use nix::sys::signal::{kill, Signal};
+use std::cmp::Ordering;
 use nix::unistd::Pid;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -258,10 +259,12 @@ type Node = (String, String, String, usize);
 // them — otherwise capture reads a node the daemon never opens.
 fn sort_nodes(nodes: &mut [Node]) {
     nodes.sort_by(|a, b| {
-        crate::input::bare_addr(&a.2)
-            .cmp(&crate::input::bare_addr(&b.2))
-            .then(b.3.cmp(&a.3))
-            .then(a.0.cmp(&b.0))
+        let (left, right) = (crate::input::bare_addr(&a.2), crate::input::bare_addr(&b.2));
+        left.cmp(&right)
+            // Only nodes of one address are ranked against each other. The
+            // built-in nodes carry no address and stay in path order.
+            .then_with(|| if left.is_empty() { Ordering::Equal } else { b.3.cmp(&a.3) })
+            .then_with(|| a.0.cmp(&b.0))
     });
 }
 
@@ -586,12 +589,13 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_nodes_keep_path_order() {
+    fn nodes_without_an_address_keep_path_order() {
         let mut nodes = vec![
-            node("/dev/input/event2", "b", "", 0),
-            node("/dev/input/event1", "a", "", 0),
+            node("/dev/input/event1", "goodix-ts", "", 4),
+            node("/dev/input/event0", "bd71828-pwrkey", "", 1),
         ];
         sort_nodes(&mut nodes);
-        assert_eq!(nodes[0].0, "/dev/input/event1");
+        let paths: Vec<&str> = nodes.iter().map(|n| n.0.as_str()).collect();
+        assert_eq!(paths, ["/dev/input/event0", "/dev/input/event1"]);
     }
 }

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -568,28 +568,23 @@ mod tests {
     }
 
     #[test]
-    fn the_node_with_the_keys_leads_its_address() {
+    fn nodes_of_one_address_lead_with_the_keys_the_rest_keep_path_order() {
         let mut nodes = vec![
             node("/dev/input/event3", "Smart 1-P Consumer Control", "E0:F6:B5:BC:1C:7F/P", 20),
+            node("/dev/input/event1", "goodix-ts", "", 4),
             node("/dev/input/event4", "Smart 1-P Keyboard", "e0:f6:b5:bc:1c:7f", 120),
-            node("/dev/input/event0", "cyttsp5_mt", "", 2),
+            node("/dev/input/event0", "bd71828-pwrkey", "", 1),
         ];
         sort_nodes(&mut nodes);
         let paths: Vec<&str> = nodes.iter().map(|n| n.0.as_str()).collect();
         assert_eq!(
             paths,
-            ["/dev/input/event0", "/dev/input/event4", "/dev/input/event3"]
+            [
+                "/dev/input/event0",
+                "/dev/input/event1",
+                "/dev/input/event4",
+                "/dev/input/event3"
+            ]
         );
-    }
-
-    #[test]
-    fn nodes_without_an_address_keep_path_order() {
-        let mut nodes = vec![
-            node("/dev/input/event1", "goodix-ts", "", 4),
-            node("/dev/input/event0", "bd71828-pwrkey", "", 1),
-        ];
-        sort_nodes(&mut nodes);
-        let paths: Vec<&str> = nodes.iter().map(|n| n.0.as_str()).collect();
-        assert_eq!(paths, ["/dev/input/event0", "/dev/input/event1"]);
     }
 }

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -1,11 +1,11 @@
 use evdev::{Device, InputEventKind};
 use log::{error, info, warn};
 use std::fs;
+use std::cmp::Ordering;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
 use nix::sys::signal::{kill, Signal};
-use std::cmp::Ordering;
 use nix::unistd::Pid;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -251,18 +251,12 @@ fn url_decode(s: &str) -> String {
 
 // ---- handlers ----
 
-// path, name, uniq, mappable keys
 type Node = (String, String, String, usize);
 
-// Frontends resolve a configured device by taking the first node whose uniq
-// matches, so nodes sharing an address go best-first the way the daemon ranks
-// them — otherwise capture reads a node the daemon never opens.
 fn sort_nodes(nodes: &mut [Node]) {
     nodes.sort_by(|a, b| {
         let (left, right) = (crate::input::bare_addr(&a.2), crate::input::bare_addr(&b.2));
         left.cmp(&right)
-            // Only nodes of one address are ranked against each other. The
-            // built-in nodes carry no address and stay in path order.
             .then_with(|| if left.is_empty() { Ordering::Equal } else { b.3.cmp(&a.3) })
             .then_with(|| a.0.cmp(&b.0))
     });

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -250,6 +250,21 @@ fn url_decode(s: &str) -> String {
 
 // ---- handlers ----
 
+// path, name, uniq, mappable keys
+type Node = (String, String, String, usize);
+
+// Frontends resolve a configured device by taking the first node whose uniq
+// matches, so nodes sharing an address go best-first the way the daemon ranks
+// them — otherwise capture reads a node the daemon never opens.
+fn sort_nodes(nodes: &mut [Node]) {
+    nodes.sort_by(|a, b| {
+        crate::input::bare_addr(&a.2)
+            .cmp(&crate::input::bare_addr(&b.2))
+            .then(b.3.cmp(&a.3))
+            .then(a.0.cmp(&b.0))
+    });
+}
+
 fn devices_json() -> String {
     let mut entries = Vec::new();
     if let Ok(dir) = fs::read_dir(INPUT_DIR) {
@@ -263,24 +278,24 @@ fn devices_json() -> String {
             if !name.starts_with("event") {
                 continue;
             }
-            let (dev_name, dev_uniq) = Device::open(&path)
+            let (dev_name, dev_uniq, keys) = Device::open(&path)
                 .ok()
                 .map(|d| {
                     let n = d.name().unwrap_or("").to_string();
                     let u = d.unique_name().unwrap_or("").to_string();
-                    (n, u)
+                    (n, u, crate::input::mappable_keys(d.supported_keys()))
                 })
                 .unwrap_or_default();
             if dev_name == "kindle-button-mapper" {
                 continue;
             }
-            entries.push((path.display().to_string(), dev_name, dev_uniq));
+            entries.push((path.display().to_string(), dev_name, dev_uniq, keys));
         }
     }
-    entries.sort();
+    sort_nodes(&mut entries);
     let items: Vec<String> = entries
         .iter()
-        .map(|(p, n, u)| format!("{{\"path\":\"{}\",\"name\":\"{}\",\"uniq\":\"{}\"}}", esc(p), esc(n), esc(u)))
+        .map(|(p, n, u, _)| format!("{{\"path\":\"{}\",\"name\":\"{}\",\"uniq\":\"{}\"}}", esc(p), esc(n), esc(u)))
         .collect();
     format!("{{\"ok\":true,\"devices\":[{}]}}", items.join(","))
 }
@@ -545,4 +560,38 @@ fn esc(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_nodes;
+
+    fn node(path: &str, name: &str, uniq: &str, keys: usize) -> super::Node {
+        (path.into(), name.into(), uniq.into(), keys)
+    }
+
+    #[test]
+    fn the_node_with_the_keys_leads_its_address() {
+        let mut nodes = vec![
+            node("/dev/input/event3", "Smart 1-P Consumer Control", "E0:F6:B5:BC:1C:7F/P", 20),
+            node("/dev/input/event4", "Smart 1-P Keyboard", "e0:f6:b5:bc:1c:7f", 120),
+            node("/dev/input/event0", "cyttsp5_mt", "", 2),
+        ];
+        sort_nodes(&mut nodes);
+        let paths: Vec<&str> = nodes.iter().map(|n| n.0.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["/dev/input/event0", "/dev/input/event4", "/dev/input/event3"]
+        );
+    }
+
+    #[test]
+    fn unrelated_nodes_keep_path_order() {
+        let mut nodes = vec![
+            node("/dev/input/event2", "b", "", 0),
+            node("/dev/input/event1", "a", "", 0),
+        ];
+        sort_nodes(&mut nodes);
+        assert_eq!(nodes[0].0, "/dev/input/event1");
+    }
 }


### PR DESCRIPTION
A remote whose report descriptor carries more than one application collection registers a node per collection. A Smart 1-P shows a `Keyboard` and a `Consumer Control` under one address.

`devices_json()` listed `/dev/input` by path, and every frontend resolves a configured device by taking the first node whose uniq matches, so capture opened whichever node the kernel happened to number lower. Landing on the Consumer Control node leaves the capture screen waiting on keys only the Keyboard node reports, until it times out. The daemon does not hit this since f289200 already scores the nodes and keeps the one with the keys, which is why existing mappings keep firing while no new one can be captured.

Nodes sharing an address now go best-first by that same score. Nodes with no address, the built-in ones, stay in path order. The KOReader plugin's `findNode()` and the app's `resolveDevicePath()` both stay as they are.

## Validated on a Kindle

This kernel is 4.9 and does not split an input device per application collection, so the two nodes were registered as two UHID devices sharing a uniq, Consumer Control first so it took the lower event number. That is what the helper sees on `/dev/input` either way. A KEY_UP press was injected on the keyboard node while `/capture` ran against the node a frontend resolves to.

Before, twice in a row

```
a frontend resolves to: /dev/input/event3 (Smart 1-P Consumer Control)
ordering: FAIL, capture reads the wrong node
capture returned: {'ok': False, 'error': 'timeout'}
```

After, twice in a row

```
a frontend resolves to: /dev/input/event4 (Smart 1-P Keyboard)
ordering: PASS
capture returned: {'ok': True, 'kind': 'key', 'code': 103}
```

The device run also caught the first cut ranking every node, which put `goodix-ts` ahead of `bd71828-pwrkey` in the app's list. `/devices` for the built-in nodes is byte-identical to master now.

Fixes zampierilucas/kindle-hid-passthrough#187