### PR TITLE
Fix tap rotation reading a property that is always empty

### DIFF
--- a/scripts/tap.sh
+++ b/scripts/tap.sh
@@ -49,14 +49,14 @@ screen_size() {
 rotation() {
     [ -n "$TAP_ROTATION" ] && { echo "$TAP_ROTATION"; return; }
     if command -v timeout >/dev/null 2>&1; then
-        o=$(timeout 1 lipc-get-prop com.lab126.system orientation 2>/dev/null)
+        o=$(timeout 1 lipc-get-prop com.lab126.winmgr orientation 2>/dev/null)
     else
-        o=$(lipc-get-prop com.lab126.system orientation 2>/dev/null)
+        o=$(lipc-get-prop com.lab126.winmgr orientation 2>/dev/null)
     fi
     case "$o" in
-        R) echo 90 ;;
+        R) echo 270 ;;
         D) echo 180 ;;
-        L) echo 270 ;;
+        L) echo 90 ;;
         *) echo 0 ;;
     esac
 }
@@ -79,9 +79,7 @@ case "$ROT" in
 esac
 
 # Some firmware swaps the reported mode with the rotation, the panel never does.
-case "$ROT" in
-    90|270) [ "$W" -gt "$H" ] && { T=$W; W=$H; H=$T; } ;;
-esac
+[ "$W" -gt "$H" ] && { T=$W; W=$H; H=$T; }
 
 X=$(( W * X_PCT / 100 ))
 Y=$(( H * Y_PCT / 100 ))


### PR DESCRIPTION
The tap rotation from #41 never did anything. `com.lab126.system orientation` reads back empty even with the framework up, so `rotation()` always hit the fallback and returned 0. Confirmed on a Kindle 11, and the reporter in #42 sees the same on an Oasis 2.

`com.lab126.winmgr orientation` is the one that answers. It returns U, R and L and follows `orientationLock`.

R and L were also backwards. I settled it by tapping the top of the page in each orientation and reading `chromeState`, which only flips when the tap lands on the visible page. R needs 270, L needs 90.

Third thing, `fb0/modes` is not a safe panel size. Once the framework has rotated once it keeps reporting the rotated geometry even after going back to portrait, so `tap.sh` was computing x=1230 on a 1072 wide panel and only working because the kernel clamps. The touchscreen never turns, ABS is fixed at 0..1072 by 0..1448, so the normalisation to portrait is now unconditional.

Verified end to end in U, R and L with automatic detection. Top tap opens the toolbar in all three, and next then prev returns to the identical framebuffer hash in all three.

Refs zampierilucas/kindle-hid-passthrough#182