### PR TITLE
Keep page turns pointing the same way after a 180 rotation

### DIFF
--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -212,8 +212,8 @@ impl Injector {
         let Injector { dev, pager } = self;
         match line {
             "" => (),
-            "page_next" => pager.turn(dev.as_mut(), KEY_PAGEDOWN, KEY_DOWN),
-            "page_prev" => pager.turn(dev.as_mut(), KEY_PAGEUP, KEY_UP),
+            "page_next" => pager.turn(dev.as_mut(), true),
+            "page_prev" => pager.turn(dev.as_mut(), false),
             _ => match crate::config::parse_key(line) {
                 Some(key) => match dev {
                     Some(vkbd) => {
@@ -237,8 +237,46 @@ impl Injector {
 /// page turn goes in as if the button had been pressed. Models without the
 /// buttons take KEY_DOWN/KEY_UP on the virtual keyboard instead.
 enum Pager {
-    Buttons { path: PathBuf, node: Option<File> },
+    Buttons {
+        path: PathBuf,
+        node: Option<File>,
+        flipped: Flipped,
+    },
     VirtualKeyboard,
+}
+
+#[derive(Default)]
+struct Flipped {
+    value: bool,
+    checked: Option<std::time::Instant>,
+}
+
+impl Flipped {
+    fn get(&mut self) -> bool {
+        if self
+            .checked
+            .is_some_and(|t| t.elapsed() < std::time::Duration::from_secs(1))
+        {
+            return self.value;
+        }
+        self.checked = Some(std::time::Instant::now());
+        self.value = matches!(orientation().as_deref(), Some("U"));
+        self.value
+    }
+}
+
+fn orientation() -> Option<String> {
+    for prop in ["orientation", "accelerometer"] {
+        let out = Command::new("lipc-get-prop")
+            .args(["com.lab126.winmgr", prop])
+            .output()
+            .ok()?;
+        let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+    None
 }
 
 impl Pager {
@@ -246,7 +284,11 @@ impl Pager {
         match page_button_node() {
             Some(path) => {
                 info!("Page turns go to the page buttons at {}", path.display());
-                Pager::Buttons { path, node: None }
+                Pager::Buttons {
+                    path,
+                    node: None,
+                    flipped: Flipped::default(),
+                }
             }
             None => {
                 info!("No page buttons found, page turns go to the virtual keyboard");
@@ -255,9 +297,18 @@ impl Pager {
         }
     }
 
-    fn turn(&mut self, vkbd: Option<&mut File>, button_code: u16, kbd_code: u16) {
+    fn turn(&mut self, vkbd: Option<&mut File>, forward: bool) {
         match self {
-            Pager::Buttons { path, node } => {
+            Pager::Buttons {
+                path,
+                node,
+                flipped,
+            } => {
+                let button_code = if forward != flipped.get() {
+                    KEY_PAGEDOWN
+                } else {
+                    KEY_PAGEUP
+                };
                 if node.is_none() {
                     match OpenOptions::new().write(true).open(&path) {
                         Ok(f) => *node = Some(f),
@@ -276,6 +327,7 @@ impl Pager {
             }
             Pager::VirtualKeyboard => match vkbd {
                 Some(vkbd) => {
+                    let kbd_code = if forward { KEY_DOWN } else { KEY_UP };
                     if let Err(e) = tap(vkbd, kbd_code) {
                         warn!("Page turn failed: {}", e);
                     }

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -9,6 +9,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use std::thread;
 
 const UINPUT_DEV: &str = "/dev/uinput";
@@ -240,43 +241,26 @@ enum Pager {
     Buttons {
         path: PathBuf,
         node: Option<File>,
-        flipped: Flipped,
+        flipped: bool,
+        checked: Option<Instant>,
     },
     VirtualKeyboard,
 }
 
-#[derive(Default)]
-struct Flipped {
-    value: bool,
-    checked: Option<std::time::Instant>,
-}
-
-impl Flipped {
-    fn get(&mut self) -> bool {
-        if self
-            .checked
-            .is_some_and(|t| t.elapsed() < std::time::Duration::from_secs(1))
-        {
-            return self.value;
-        }
-        self.checked = Some(std::time::Instant::now());
-        self.value = matches!(orientation().as_deref(), Some("U"));
-        self.value
-    }
-}
-
-fn orientation() -> Option<String> {
+fn held_upside_down() -> bool {
     for prop in ["orientation", "accelerometer"] {
-        let out = Command::new("lipc-get-prop")
+        let Ok(out) = Command::new("lipc-get-prop")
             .args(["com.lab126.winmgr", prop])
             .output()
-            .ok()?;
-        let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if !value.is_empty() {
-            return Some(value);
+        else {
+            continue;
+        };
+        match String::from_utf8_lossy(&out.stdout).trim() {
+            "" => continue,
+            value => return value == "U",
         }
     }
-    None
+    false
 }
 
 impl Pager {
@@ -287,7 +271,8 @@ impl Pager {
                 Pager::Buttons {
                     path,
                     node: None,
-                    flipped: Flipped::default(),
+                    flipped: false,
+                    checked: None,
                 }
             }
             None => {
@@ -303,8 +288,13 @@ impl Pager {
                 path,
                 node,
                 flipped,
+                checked,
             } => {
-                let button_code = if forward != flipped.get() {
+                if checked.is_none_or(|t| t.elapsed() > Duration::from_secs(1)) {
+                    *checked = Some(Instant::now());
+                    *flipped = held_upside_down();
+                }
+                let button_code = if forward != *flipped {
                     KEY_PAGEDOWN
                 } else {
                     KEY_PAGEUP


### PR DESCRIPTION
On a Kindle with physical page buttons the framework picks which button means forward from the orientation, since real buttons swap ends when you turn the device over. `Pager::Buttons` writes `KEY_PAGEDOWN` straight into that node, so our injection inherits the swap and `next_page` walks backwards. That is what @xbot hit in #42 on an Oasis 2.

The fix reads the orientation and inverts the code when the framework has already inverted it. Cached for a second so a page turn still costs no fork in the normal case, and an unreadable orientation means no inversion, which is exactly what the daemon does today.

Two things I could not verify, so this wants a test on real hardware before merging.

I do not have a device with physical page buttons, so the `Pager::Buttons` path is unexercised. My Kindle 11 only takes the virtual keyboard path.

More importantly, the inversion triggers on orientation `U`, which comes straight from the one measurement in #42 (works in `D`, reversed in `U`). If the Oasis 1, Oasis 3 or Voyage report the opposite letter for their natural hold, the condition is backwards for them. I would rather have that confirmed than guess twice in a row.

@xbot if you build this, could you also paste `lipc-get-prop com.lab126.winmgr orientation` and `lipc-get-prop com.lab126.winmgr pageTurnkeyConfig` in both positions? If `pageTurnkeyConfig` flips on its own it is a better signal than the orientation letter and I would switch to it.

Refs #42