### PR TITLE
Use a mouse as a mouse, or map its buttons

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p output/scripts output/illusion/MapperManager output/assets
           cp target/armv7-unknown-linux-musleabihf/release/kindle-button-mapper output/
           cp install.sh uninstall.sh config.ini output/
-          cp assets/kindle-button-mapper.upstart output/assets/
+          cp assets/kindle-button-mapper.upstart assets/99-kindle-button-mapper-pointer.rules output/assets/
           cp scripts/*.sh output/scripts/
           cp illusion/MapperManager.sh illusion/install-waf-app.sh output/illusion/
           cp illusion/MapperManager/config.xml illusion/MapperManager/index.html \
@@ -81,6 +81,7 @@ jobs:
             uninstall.sh \
             config.ini \
             assets/kindle-button-mapper.upstart \
+            assets/99-kindle-button-mapper-pointer.rules \
             $(ls scripts/*.sh) \
             illusion/MapperManager.sh \
             illusion/install-waf-app.sh \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ on_disconnect = /path/to/script.sh
 name = Device Name
 uniq = AA:BB:CC:DD:EE:FF   # Bluetooth MAC; matched first when set
 grab = true
+# type = mouse             # map a mouse's buttons, keep it pointing
 # keyboard_layout = fr     # XKB layout override (comma list for an Alt+Shift toggle, e.g. us,ru)
 
 [device.gamepad.buttons]
@@ -99,6 +100,14 @@ unstable across reconnects): the mapper uses the Bluetooth MAC (`uniq`) when set
 otherwise the device `name`. Set at least one.
 
 Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to type correctly on a non-US Bluetooth keyboard. The reader re-pins the `us` core keymap on every focus and `/usr/share/X11/xkb` is read-only, so the mapper bind-mounts a generated `us` symbols file over the system one; every re-pin then resolves to your layout, reverted when the daemon stops. Give a comma list for an Alt+Shift toggle (`us,ru`); it's a system-wide override taken from the first device that sets one. Leave it unset to keep the system default.
+
+Set `type = mouse` on a mouse. Sharing one means every mapped click also lands
+as a tap on whatever is under the cursor, and taking it exclusively to stop that
+freezes the pointer, since nothing else can read the device any more. With
+`type = mouse` the mapper holds the mouse, opens the node carrying the buttons
+rather than any second node the device registers, and re-emits the movement, the
+wheel and the buttons you left unmapped through a virtual pointer, so the cursor
+still moves and the rest of the buttons still click.
 
 A button fires as soon as it goes down. Give it a `longpress` mapping and it
 fires on release instead, since a short press is only a short press once you

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ on_disconnect = /path/to/script.sh
 name = Device Name
 uniq = AA:BB:CC:DD:EE:FF   # Bluetooth MAC; matched first when set
 grab = true
-# type = mouse             # map a mouse's buttons, keep it pointing
+# type = mouse             # mapped buttons act instead of clicking
 # keyboard_layout = fr     # XKB layout override (comma list for an Alt+Shift toggle, e.g. us,ru)
 
 [device.gamepad.buttons]
@@ -101,13 +101,9 @@ otherwise the device `name`. Set at least one.
 
 Set `keyboard_layout` to an XKB layout code (e.g. `fr`, `de`, `ro`, `fr(oss)`) to type correctly on a non-US Bluetooth keyboard. The reader re-pins the `us` core keymap on every focus and `/usr/share/X11/xkb` is read-only, so the mapper bind-mounts a generated `us` symbols file over the system one; every re-pin then resolves to your layout, reverted when the daemon stops. Give a comma list for an Alt+Shift toggle (`us,ru`); it's a system-wide override taken from the first device that sets one. Leave it unset to keep the system default.
 
-Set `type = mouse` on a mouse. Sharing one means every mapped click also lands
-as a tap on whatever is under the cursor, and taking it exclusively to stop that
-freezes the pointer, since nothing else can read the device any more. With
-`type = mouse` the mapper holds the mouse, opens the node carrying the buttons
-rather than any second node the device registers, and re-emits the movement, the
-wheel and the buttons you left unmapped through a virtual pointer, so the cursor
-still moves and the rest of the buttons still click.
+Set `type = mouse` to map a mouse's buttons. Mapped buttons run their action
+instead of clicking; the pointer, wheel and unmapped buttons keep working as a
+normal mouse.
 
 A button fires as soon as it goes down. Give it a `longpress` mapping and it
 fires on release instead, since a short press is only a short press once you

--- a/assets/99-kindle-button-mapper-pointer.rules
+++ b/assets/99-kindle-button-mapper-pointer.rules
@@ -1,0 +1,3 @@
+# Xorg's pointer catchall only matches ID_INPUT_MOUSE, and stock Kindle udev
+# tags nothing, so without this X never adds the mapper's virtual pointer.
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="kindle-button-mapper-pointer", ENV{ID_INPUT}="1", ENV{ID_INPUT_MOUSE}="1"

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -97,6 +97,10 @@
                 <button id="devDetailGrab" class="toggle"><span class="toggle-knob"></span></button>
             </div>
             <div class="detail-row">
+                <span class="detail-label">Mouse <button id="devDetailMouseInfo" class="info-btn" type="button">i</button></span>
+                <button id="devDetailMouse" class="toggle"><span class="toggle-knob"></span></button>
+            </div>
+            <div class="detail-row">
                 <span class="detail-label">Layout <button id="devDetailLayoutInfo" class="info-btn" type="button">i</button></span>
                 <button id="devDetailLayout" class="detail-input detail-picker" type="button" data-code="">(system default)</button>
             </div>

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -97,7 +97,7 @@
                 <button id="devDetailGrab" class="toggle"><span class="toggle-knob"></span></button>
             </div>
             <div class="detail-row">
-                <span class="detail-label">Mouse <button id="devDetailMouseInfo" class="info-btn" type="button">i</button></span>
+                <span class="detail-label">Map mouse buttons <button id="devDetailMouseInfo" class="info-btn" type="button">i</button></span>
                 <button id="devDetailMouse" class="toggle"><span class="toggle-knob"></span></button>
             </div>
             <div class="detail-row">

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -993,6 +993,7 @@ var MapperManager = (function() {
         getEl("devDetailName").value = prefillName || "";
         getEl("devDetailUniq").value = prefillUniq || "";
         getEl("devDetailGrab").className = "toggle";
+        getEl("devDetailMouse").className = "toggle";
         setDeviceLayout("");
         getEl("btnDeviceDelete").style.display = "none";
         updateDeviceIdView();
@@ -1006,6 +1007,8 @@ var MapperManager = (function() {
         getEl("devDetailUniq").value = getValue("device." + id, "uniq") || "";
         var grab = (getValue("device." + id, "grab") || "").toLowerCase() === "true";
         getEl("devDetailGrab").className = "toggle" + (grab ? " on" : "");
+        var mouse = (getValue("device." + id, "type") || "").toLowerCase() === "mouse";
+        getEl("devDetailMouse").className = "toggle" + (mouse ? " on" : "");
         setDeviceLayout(getValue("device." + id, "keyboard_layout") || "");
         getEl("btnDeviceDelete").style.display = "block";
         getEl("devDetailIdView").innerHTML = escapeHtml(id);
@@ -1025,6 +1028,13 @@ var MapperManager = (function() {
         t.className = t.className.indexOf(" on") >= 0 ? "toggle" : "toggle on";
     }
 
+    function toggleDeviceDetailMouse() {
+        var t = getEl("devDetailMouse");
+        var on = t.className.indexOf(" on") < 0;
+        t.className = on ? "toggle on" : "toggle";
+        if (on) { getEl("devDetailGrab").className = "toggle on"; }
+    }
+
     function autoIdFromName(s) {
         return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").substring(0, 30) || "device";
     }
@@ -1042,6 +1052,7 @@ var MapperManager = (function() {
             return;
         }
         var exclusive = getEl("devDetailGrab").className.indexOf(" on") >= 0;
+        var mouse = getEl("devDetailMouse").className.indexOf(" on") >= 0;
 
         if (!editingDeviceId && listDeviceIds().indexOf(newId) >= 0) {
             showMessage("A device with that name already exists", true);
@@ -1056,6 +1067,7 @@ var MapperManager = (function() {
         setValue(section, "name", name);
         setOrDel(section, "grab", pinned ? String(exclusive) : "");
         setOrDel(section, "uniq", uniq);
+        setOrDel(section, "type", mouse ? "mouse" : "");
         setOrDel(section, "keyboard_layout", layout);
         delValue(section, "path");
 
@@ -1226,6 +1238,10 @@ var MapperManager = (function() {
         }, false);
         getEl("devDetailGrabInfo").addEventListener("click", function() {
             showInfo("Exclusive: take sole ownership of the input device so other apps (e.g. the Kindle reader) don't also react to its events. Recommended for gamepads and remotes when you only want the mapper to handle them.");
+        }, false);
+        getEl("devDetailMouse").addEventListener("click", toggleDeviceDetailMouse, false);
+        getEl("devDetailMouseInfo").addEventListener("click", function() {
+            showInfo("Mouse: map this device's buttons instead of letting them click. The mapper takes the mouse exclusively, so a mapped button no longer also taps the screen, and re-emits the movement, the wheel and every button you left unmapped, so it still works as a mouse.");
         }, false);
         getEl("devDetailLayoutInfo").addEventListener("click", function() {
             showInfo("Keyboard layout: pick an XKB layout re-applied every time this keyboard connects, so a non-US layout survives reconnects. Choose (system default) to leave the layout untouched.");

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -203,7 +203,7 @@ var MapperManager = (function() {
     function hideOverlay(id) { getEl(id).className = "overlay"; }
 
     function showInfo(text) {
-        getEl("infoMessage").innerHTML = escapeHtml(text);
+        getEl("infoMessage").innerHTML = escapeHtml(text).replace(/\n/g, "<br/>");
         showOverlay("infoOverlay");
     }
 
@@ -1241,7 +1241,7 @@ var MapperManager = (function() {
         }, false);
         getEl("devDetailMouse").addEventListener("click", toggleDeviceDetailMouse, false);
         getEl("devDetailMouseInfo").addEventListener("click", function() {
-            showInfo("Mouse: map this device's buttons instead of letting them click. The mapper takes the mouse exclusively, so a mapped button no longer also taps the screen, and re-emits the movement, the wheel and every button you left unmapped, so it still works as a mouse.");
+            showInfo("Buttons you map run their action instead of clicking.\nThe pointer, wheel and unmapped buttons keep working as a normal mouse.\nTurns on Exclusive, the mapper needs to own the device.");
         }, false);
         getEl("devDetailLayoutInfo").addEventListener("click", function() {
             showInfo("Keyboard layout: pick an XKB layout re-applied every time this keyboard connects, so a non-US layout survives reconnects. Choose (system default) to leave the layout untouched.");

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,10 @@ rm -f "$INSTALL_DIR/boot_attempts"
 
 cp "$INSTALL_DIR/assets/kindle-button-mapper.upstart" /etc/upstart/kindle-button-mapper.conf
 
+# udevd reads its rules once, so a fresh install has to say so.
+cp "$INSTALL_DIR/assets/99-kindle-button-mapper-pointer.rules" /etc/udev/rules.d/
+killall -HUP udevd 2>/dev/null || true
+
 cp "$INSTALL_DIR/illusion/MapperManager.sh" /mnt/us/documents/MapperManager.sh
 chmod +x /mnt/us/documents/MapperManager.sh
 

--- a/justfile
+++ b/justfile
@@ -59,6 +59,8 @@ deploy: build-kindle
     scp scripts/*.sh kindle:/mnt/us/kindle-button-mapper/scripts/
     ssh kindle "chmod +x /mnt/us/kindle-button-mapper/scripts/*.sh"
     scp assets/kindle-button-mapper.upstart kindle:/etc/upstart/kindle-button-mapper.conf
+    scp assets/99-kindle-button-mapper-pointer.rules kindle:/etc/udev/rules.d/
+    ssh kindle "killall -HUP udevd || true"
     @echo "Deployment complete!"
     @echo ""
     @echo "Start daemon with: just start"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,8 @@ pub struct DeviceConfig {
     /// Re-emit keys with no mapping through the virtual keyboard. Only means
     /// anything alongside a grab, and it is what makes a keyboard survive one.
     pub passthrough: bool,
-    /// Hold the mouse and relay what is not mapped, instead of sharing it.
+    /// Map this mouse's buttons. Everything unmapped is relayed, so the rest
+    /// of the mouse keeps working.
     pub mouse: bool,
     pub keyboard_layout: Option<String>,
     pub mappings: HashMap<Key, String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct DeviceConfig {
     /// Re-emit keys with no mapping through the virtual keyboard. Only means
     /// anything alongside a grab, and it is what makes a keyboard survive one.
     pub passthrough: bool,
+    /// Hold the mouse and relay what is not mapped, instead of sharing it.
+    pub mouse: bool,
     pub keyboard_layout: Option<String>,
     pub mappings: HashMap<Key, String>,
     pub long_press_mappings: HashMap<Key, String>,
@@ -100,6 +102,7 @@ impl DeviceConfig {
             grab: true,
             grab_explicit: false,
             passthrough: false,
+            mouse: false,
             keyboard_layout: None,
             mappings: HashMap::new(),
             long_press_mappings: HashMap::new(),
@@ -253,6 +256,9 @@ impl Config {
                         dev.grab_explicit = true;
                     }
                     if let Some(v) = get(entries, "passthrough") { dev.passthrough = parse_bool(v); }
+                    if let Some(v) = get(entries, "type") {
+                        dev.mouse = v.trim().eq_ignore_ascii_case("mouse");
+                    }
                     dev.keyboard_layout = get(entries, "keyboard_layout")
                         .map(str::trim)
                         .filter(|v| !v.is_empty())
@@ -425,6 +431,18 @@ mod tests {
         assert!(!pad.passthrough);
         let kbd = cfg.devices.iter().find(|d| d.id == "kbd").expect("kbd");
         assert!(kbd.passthrough && kbd.grab && kbd.grab_explicit);
+    }
+
+    #[test]
+    fn type_mouse_is_the_only_type_that_changes_anything() {
+        let cfg = load_str(
+            "kbm-type.ini",
+            "[device.mouse]\nuniq = AA:BB:CC:DD:EE:FF\ntype = Mouse\n\n[device.pad]\nuniq = 11:22:33:44:55:66\n\n[device.kbd]\nuniq = 22:33:44:55:66:77\ntype = keyboard\n",
+        );
+        let by = |id: &str| cfg.devices.iter().find(|d| d.id == id).expect("device");
+        assert!(by("mouse").mouse);
+        assert!(!by("pad").mouse);
+        assert!(!by("kbd").mouse);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,10 +22,10 @@ pub fn uniq_matches(node: &str, want: &str) -> bool {
     !want.is_empty() && bare_addr(node) == bare_addr(want)
 }
 
-pub fn mappable_keys(keys: Option<&AttributeSetRef<Key>>) -> usize {
+pub fn mappable_keys(keys: Option<&AttributeSetRef<Key>>, mouse: bool) -> usize {
     let mouse_buttons = Key::BTN_LEFT.code()..=Key::BTN_TASK.code();
     keys.map_or(0, |keys| {
-        keys.iter().filter(|k| !mouse_buttons.contains(&k.code())).count()
+        keys.iter().filter(|k| mouse_buttons.contains(&k.code()) == mouse).count()
     })
 }
 
@@ -33,6 +33,7 @@ pub struct InputHandler {
     device_name: Option<String>,
     device_uniq: Option<String>,
     grab: bool,
+    mouse: bool,
 }
 
 impl InputHandler {
@@ -40,11 +41,13 @@ impl InputHandler {
         device_name: Option<String>,
         device_uniq: Option<String>,
         grab: bool,
+        mouse: bool,
     ) -> Self {
         Self {
             device_name,
             device_uniq,
             grab,
+            mouse,
         }
     }
 
@@ -65,7 +68,7 @@ impl InputHandler {
     }
 
     fn matches_device(&self, dev: &Device) -> bool {
-        if dev.name().unwrap_or("") == "kindle-button-mapper" {
+        if dev.name().unwrap_or("").starts_with("kindle-button-mapper") {
             return false;
         }
         // uniq (MAC) is stable across renames and reconnects — match on it
@@ -104,7 +107,7 @@ impl InputHandler {
                     if !self.matches_device(&dev) {
                         continue;
                     }
-                    let keys = mappable_keys(dev.supported_keys());
+                    let keys = mappable_keys(dev.supported_keys(), self.mouse);
                     debug!("{} matches, {} mappable keys", path.display(), keys);
                     if best.as_ref().is_none_or(|(most, _, _)| keys > *most) {
                         best = Some((keys, path, dev));
@@ -165,8 +168,8 @@ impl InputHandler {
     /// grab is not fatal, but the caller has to know: whoever holds it still
     /// gets the events, so anything that assumes exclusivity would double up.
     fn finish_open(&self, mut device: Device) -> Result<(Device, bool), String> {
-        if device.name().unwrap_or("") == "kindle-button-mapper" {
-            return Err("Refusing to read our own virtual keyboard".to_string());
+        if device.name().unwrap_or("").starts_with("kindle-button-mapper") {
+            return Err("Refusing to read our own virtual device".to_string());
         }
         let mut grabbed = false;
         if self.grab {
@@ -198,10 +201,19 @@ mod tests {
         let keyboard = AttributeSet::from_iter([Key::KEY_A, Key::KEY_PAGEUP, Key::KEY_PAGEDOWN]);
         let gamepad = AttributeSet::from_iter([Key::BTN_SOUTH, Key::BTN_EAST]);
 
-        assert_eq!(mappable_keys(Some(&mouse)), 0);
-        assert_eq!(mappable_keys(Some(&keyboard)), 3);
-        assert_eq!(mappable_keys(Some(&gamepad)), 2);
-        assert_eq!(mappable_keys(None), 0);
+        assert_eq!(mappable_keys(Some(&mouse), false), 0);
+        assert_eq!(mappable_keys(Some(&keyboard), false), 3);
+        assert_eq!(mappable_keys(Some(&gamepad), false), 2);
+        assert_eq!(mappable_keys(None, false), 0);
+    }
+
+    #[test]
+    fn a_mouse_device_picks_the_node_with_the_buttons() {
+        let buttons = AttributeSet::from_iter([Key::BTN_LEFT, Key::BTN_RIGHT, Key::BTN_MIDDLE]);
+        let consumer = AttributeSet::from_iter([Key::KEY_PLAYPAUSE, Key::KEY_VOLUMEUP]);
+
+        assert!(mappable_keys(Some(&buttons), true) > mappable_keys(Some(&consumer), true));
+        assert!(mappable_keys(Some(&buttons), false) < mappable_keys(Some(&consumer), false));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
     let mut generation = reload::generation();
 
     loop {
-        let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab);
+        let handler = InputHandler::new(cfg.name.clone(), cfg.uniq.clone(), cfg.grab, cfg.mouse);
         match handler.open() {
             Ok((mut device, grabbed_at_open)) => {
                 // Only the opened node says whether this is a pad or a
@@ -249,14 +249,7 @@ fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
                         }
                     }
                 }
-                // Relaying keys we do not hold would deliver every keystroke
-                // twice, once from us and once from whoever does hold it.
-                if cfg.passthrough && !grab {
-                    warn!(
-                        "[{}] passthrough needs the exclusive grab and something else has it, relaying is off",
-                        cfg.id
-                    );
-                    cfg.passthrough = false;
+                if downgrade_relay(&mut cfg, grab) {
                     mapper = Mapper::new(&cfg, &settings);
                 }
                 if grab && cfg.passthrough && !vkeyboard::available() {
@@ -265,14 +258,21 @@ fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
                         cfg.id
                     );
                 }
+                if grab && cfg.mouse && !vkeyboard::pointer_ready() {
+                    warn!(
+                        "[{}] no uinput pointer, the cursor will not move while we hold the mouse",
+                        cfg.id
+                    );
+                }
 
                 info!(
                     "[{}] device connected ({})",
                     cfg.id,
-                    match (grab, cfg.passthrough) {
-                        (false, _) => "shared",
-                        (true, true) => "exclusive, unmapped keys passed through",
-                        (true, false) => "exclusive",
+                    match (grab, cfg.mouse, cfg.passthrough) {
+                        (false, _, _) => "shared",
+                        (true, true, _) => "exclusive, motion and unmapped buttons relayed",
+                        (true, false, true) => "exclusive, unmapped keys passed through",
+                        (true, false, false) => "exclusive",
                     }
                 );
                 if let Some(ref script) = settings.on_connect {
@@ -337,12 +337,11 @@ fn run_event_loop(
         if current != *generation {
             *generation = current;
             match reload::device_config(&cfg.id) {
-                Some(fresh) => {
+                Some(mut fresh) => {
                     info!("[{}] applying reloaded mappings", cfg.id);
                     if let Some(globals) = reload::settings() {
                         *settings = globals;
                     }
-                    *mapper = Mapper::new(&fresh, settings);
                     // Switching who owns the device has to bite now rather
                     // than on the next reconnect, or the toggle looks broken.
                     let want = effective_grab(&fresh, gamepad);
@@ -358,6 +357,8 @@ fn run_event_loop(
                             Err(e) => warn!("[{}] cannot change who holds the device: {}", cfg.id, e),
                         }
                     }
+                    downgrade_relay(&mut fresh, grab);
+                    *mapper = Mapper::new(&fresh, settings);
                     *cfg = fresh;
                 }
                 None => {
@@ -403,10 +404,17 @@ fn run_event_loop(
             continue;
         }
 
+        let relay = cfg.mouse && grab;
+
         let mut activity = false;
         for event in events {
             match event.kind() {
-                InputEventKind::Synchronization(_) => mapper.handle_sync(),
+                InputEventKind::Synchronization(_) => {
+                    mapper.handle_sync();
+                    if relay {
+                        vkeyboard::pointer_sync();
+                    }
+                }
                 InputEventKind::Key(key) if key.code() == 330 => {  // BTN_TOUCH
                     activity = true;
                     mapper.handle_touch(event.value() == 1);
@@ -448,6 +456,10 @@ fn run_event_loop(
                         _ => {}
                     }
                 }
+                InputEventKind::RelAxis(axis) if relay => {
+                    activity = true;
+                    vkeyboard::pointer_motion(axis.0, event.value());
+                }
                 _ => {}
             }
         }
@@ -464,10 +476,25 @@ fn run_event_loop(
 }
 
 /// Whether the daemon should hold this device exclusively. An explicit `grab`
-/// in the file is taken at its word; without one only a gamepad is claimed,
-/// since grabbing a keyboard would swallow every key nothing maps.
+/// in the file is taken at its word; without one only a gamepad or a mouse is
+/// claimed, since grabbing a keyboard would swallow every key nothing maps.
 fn effective_grab(cfg: &config::DeviceConfig, gamepad: bool) -> bool {
-    cfg.grab && (cfg.grab_explicit || gamepad)
+    cfg.grab && (cfg.grab_explicit || gamepad || cfg.mouse)
+}
+
+/// Relaying a device we do not hold would deliver everything twice. True when
+/// something was turned off and the mapper has to be rebuilt.
+fn downgrade_relay(cfg: &mut config::DeviceConfig, grab: bool) -> bool {
+    if grab || !(cfg.passthrough || cfg.mouse) {
+        return false;
+    }
+    warn!(
+        "[{}] relaying needs the exclusive grab and something else has it, it is off",
+        cfg.id
+    );
+    cfg.passthrough = false;
+    cfg.mouse = false;
+    true
 }
 
 /// Centre and half-travel per axis; pads disagree on range, the mapper sees a percentage.

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -45,6 +45,10 @@ pub struct Mapper {
     trigger_longpress_fired: HashMap<Trigger, bool>,
 }
 
+fn is_mouse_button(key: Key) -> bool {
+    (Key::BTN_LEFT.code()..=Key::BTN_TASK.code()).contains(&key.code())
+}
+
 impl Mapper {
     pub fn new(cfg: &DeviceConfig, s: &crate::WorkerSettings) -> Self {
         Self {
@@ -67,7 +71,7 @@ impl Mapper {
             long_press_ms: s.long_press_ms,
             repeat_ms: s.repeat_ms,
             log_buttons: s.log_buttons,
-            passthrough: cfg.passthrough,
+            passthrough: cfg.passthrough || cfg.mouse,
             last_press: HashMap::new(),
             press_start: HashMap::new(),
             long_press_fired: HashMap::new(),
@@ -98,8 +102,13 @@ impl Mapper {
         if !self.passthrough || self.claims(key) {
             return false;
         }
-        if !vkeyboard::forward(key.code(), value) {
-            debug!("Passthrough dropped {:?}, no virtual keyboard", key);
+        let relayed = if is_mouse_button(key) {
+            vkeyboard::pointer_button(key.code(), value)
+        } else {
+            vkeyboard::forward(key.code(), value)
+        };
+        if !relayed {
+            debug!("Passthrough dropped {:?}, no virtual device to relay into", key);
         }
         true
     }

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -34,6 +34,7 @@ const SYN_REPORT: u16 = 0x00;
 ioctl_none!(ui_dev_create, b'U', 1);
 ioctl_write_int!(ui_set_evbit, b'U', 100);
 ioctl_write_int!(ui_set_keybit, b'U', 101);
+ioctl_write_int!(ui_set_relbit, b'U', 102);
 ioctl_read_buf!(ui_get_sysname, b'U', 44, u8);
 
 // Kernel layout: the timestamp is a pair of kernel longs, not libc time_t —
@@ -390,6 +391,132 @@ fn write_event(dev: &mut File, kind: u16, code: u16, value: i32) -> io::Result<(
         )
     };
     dev.write_all(bytes)
+}
+
+// ---- virtual pointer ----
+//
+// Where a held mouse's unmapped events go, so the grab does not take the cursor
+// with it. Created on demand, a Kindle with no mouse should not grow one.
+
+const POINTER_NAME: &[u8] = b"kindle-button-mapper-pointer";
+const EV_REL: u16 = 0x02;
+/// REL_X, REL_Y, REL_HWHEEL, REL_WHEEL. Anything else is dropped.
+const REL_AXES: [u16; 4] = [0, 1, 6, 8];
+const BTN_LEFT: u16 = 0x110;
+const BTN_TASK: u16 = 0x117;
+
+struct Pointer {
+    dev: Option<File>,
+    pending: bool,
+}
+
+static POINTER: OnceLock<Mutex<Pointer>> = OnceLock::new();
+
+fn pointer() -> &'static Mutex<Pointer> {
+    POINTER.get_or_init(|| {
+        let dev = match ensure_uinput_node().map_err(io::Error::other).and_then(|()| create_pointer()) {
+            Ok(f) => {
+                match dev_node(&f) {
+                    Ok(path) => info!("Virtual pointer at {}", path.display()),
+                    Err(e) => warn!("Cannot resolve virtual pointer node: {}", e),
+                }
+                Some(f)
+            }
+            Err(e) => {
+                warn!("uinput pointer create failed: {} — a held mouse will not move the cursor", e);
+                None
+            }
+        };
+        Mutex::new(Pointer { dev, pending: false })
+    })
+}
+
+/// Creates the pointer on the first call.
+pub fn pointer_ready() -> bool {
+    pointer().lock().unwrap_or_else(|p| p.into_inner()).dev.is_some()
+}
+
+/// Nothing moves until `pointer_sync`.
+pub fn pointer_motion(code: u16, value: i32) -> bool {
+    REL_AXES.contains(&code) && pointer_write(EV_REL, code, value)
+}
+
+pub fn pointer_button(code: u16, value: i32) -> bool {
+    (BTN_LEFT..=BTN_TASK).contains(&code) && pointer_write(EV_KEY, code, value)
+}
+
+/// Mirrors the source device's SYN_REPORT, so a batch of motion lands as one
+/// move. A no-op when nothing was relayed.
+pub fn pointer_sync() {
+    let mut p = pointer().lock().unwrap_or_else(|p| p.into_inner());
+    if !p.pending {
+        return;
+    }
+    p.pending = false;
+    if let Some(ref mut dev) = p.dev {
+        if let Err(e) = write_event(dev, EV_SYN, SYN_REPORT, 0) {
+            warn!("Pointer sync failed: {}", e);
+        }
+    }
+}
+
+fn pointer_write(kind: u16, code: u16, value: i32) -> bool {
+    let mut p = pointer().lock().unwrap_or_else(|p| p.into_inner());
+    let written = match p.dev {
+        Some(ref mut dev) => match write_event(dev, kind, code, value) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("Pointer relay of {:#x} failed: {}", code, e);
+                false
+            }
+        },
+        None => false,
+    };
+    if written {
+        p.pending = true;
+    }
+    written
+}
+
+fn create_pointer() -> io::Result<File> {
+    let file = OpenOptions::new().read(true).write(true).open(UINPUT_DEV)?;
+    let fd = file.as_raw_fd();
+
+    unsafe { ui_set_evbit(fd, EV_KEY as u32 as _) }?;
+    for code in BTN_LEFT..=BTN_TASK {
+        unsafe { ui_set_keybit(fd, code as _) }?;
+    }
+    unsafe { ui_set_evbit(fd, EV_REL as u32 as _) }?;
+    for code in REL_AXES {
+        unsafe { ui_set_relbit(fd, code as _) }?;
+    }
+
+    let mut setup = UinputUserDev {
+        name: [0; UINPUT_MAX_NAME_SIZE],
+        id: InputId {
+            bustype: 0x03, // BUS_USB
+            vendor: 0x1234,
+            product: 0x5679,
+            version: 0x111,
+        },
+        ff_effects_max: 0,
+        absmax: [0; ABS_CNT],
+        absmin: [0; ABS_CNT],
+        absfuzz: [0; ABS_CNT],
+        absflat: [0; ABS_CNT],
+    };
+    setup.name[..POINTER_NAME.len()].copy_from_slice(POINTER_NAME);
+
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            (&setup as *const UinputUserDev).cast::<u8>(),
+            mem::size_of::<UinputUserDev>(),
+        )
+    };
+    (&file).write_all(bytes)?;
+
+    unsafe { ui_dev_create(fd) }?;
+    Ok(file)
 }
 
 fn create_device() -> io::Result<File> {

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -281,10 +281,10 @@ fn devices_json() -> String {
                 .map(|d| {
                     let n = d.name().unwrap_or("").to_string();
                     let u = d.unique_name().unwrap_or("").to_string();
-                    (n, u, crate::input::mappable_keys(d.supported_keys()))
+                    (n, u, crate::input::mappable_keys(d.supported_keys(), false))
                 })
                 .unwrap_or_default();
-            if dev_name == "kindle-button-mapper" {
+            if dev_name.starts_with("kindle-button-mapper") {
                 continue;
             }
             entries.push((path.display().to_string(), dev_name, dev_uniq, keys));

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,6 +17,7 @@ sleep 1
 /usr/sbin/mntroot rw
 
 rm -f /etc/upstart/kindle-button-mapper.conf
+rm -f /etc/udev/rules.d/99-kindle-button-mapper-pointer.rules
 # Drop the job from upstart now that its .conf is gone, so it isn't left as a
 # known-but-fileless job until the next reboot.
 /sbin/initctl reload-configuration 2>/dev/null || true


### PR DESCRIPTION
Either you use a mouse as a mouse, or you map its buttons. Right now you can't pick. Sharing the device means a mapped click fires the mapping and clicks as well, and grabbing it to stop that freezes the pointer, which is where #21 ended up after trying both.

`type = mouse` on a device, or the Mouse toggle in the app, makes a mapped button run its action instead of clicking. The pointer, the wheel and any button left unmapped keep working as a normal mouse, relayed through a second uinput device.

Xorg's pointer catchall only matches `ID_INPUT_MOUSE` and stock Kindle udev tags nothing, so install drops a rule for the pointer node and HUPs udevd. Without it X never adds the node.

## Validated on a Basic 5

Against a uinput mouse driven over a fifo, with `272 = /bin/true` mapped and `273` left alone.

```
mapped BTN_LEFT    -> Button: BTN_LEFT (code: 272) -> /bin/true, X mask 0x0
unmapped BTN_RIGHT -> X mask 0x400
motion             -> X pointer (0, 0) -> (353, 265)
Xorg: config/udev: Adding input device kindle-button-mapper-pointer (/dev/input/event5)
```

A real Bluetooth mouse is still untested.

Fixes #21
