### PR TITLE
feat: swipes and sticks fire existing mappings (#40)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,8 @@
 # Kindle Button Mapper - multi-device config
 # Each device has its own [device.NAME] block plus [device.NAME.{kind}]
 # subsections for buttons, longpress, dpad, dpad_longpress, triggers,
-# triggers_longpress. Edit via the WAF or by hand.
+# triggers_longpress, stick_left, stick_right, gestures. Edit via the WAF or
+# by hand.
 
 [settings]
 debounce_ms = 0
@@ -9,6 +10,17 @@ log_buttons = true
 long_press_ms = 500
 repeat_ms = 100
 keep_awake = true
+# How far a stick must travel from centre before it counts as pushed.
+stick_deadzone = 50
+# How far a contact must travel, as a percent of the axis range, before it
+# counts as a gesture rather than a tap.
+gesture_min_percent = 15
+# How closely a movement must match a recorded one. Lower is stricter.
+gesture_tolerance = 0.30
+
+# Recorded gestures live here, written by the Record gesture button.
+# [gestures]
+# flick_left = -1.000,0.021 -0.870,0.019 ...
 
 # [device.gamepad]
 # name = HID Device
@@ -27,6 +39,15 @@ keep_awake = true
 # down = /mnt/us/kindle-button-mapper/scripts/kindle.sh next_page
 # left = /mnt/us/kindle-button-mapper/scripts/kindle.sh back
 # right = /mnt/us/kindle-button-mapper/scripts/kindle.sh toolbar
+#
+# [device.gamepad.stick_left]
+# left = /mnt/us/kindle-button-mapper/scripts/kindle.sh prev_page
+# right = /mnt/us/kindle-button-mapper/scripts/kindle.sh next_page
+#
+# Recorded gestures bind by name, whatever shape they are.
+#
+# [device.gamepad.gestures]
+# flick_left = /mnt/us/kindle-button-mapper/scripts/kindle.sh next_page
 #
 # [device.gamepad.triggers]
 # lt = /mnt/us/kindle-button-mapper/scripts/kindle.sh brightness 1

--- a/illusion/MapperManager/index.html
+++ b/illusion/MapperManager/index.html
@@ -125,9 +125,21 @@
         <div class="dialog dialog-tall dialog-wide">
             <p>Logs</p>
             <pre id="logsContent" class="logs-content"></pre>
-            <div class="actions-row">
+            <div id="logsActions" class="actions-row">
                 <button id="btnLogsRefresh" class="btn btn-half">Refresh</button>
                 <button id="btnLogsClose" class="btn btn-half">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Name overlay -->
+    <div id="nameOverlay" class="overlay">
+        <div class="dialog">
+            <p id="nameTitle">Name this gesture</p>
+            <input id="nameInput" class="detail-input" type="text" />
+            <div class="actions-row">
+                <button id="btnNameOk" class="btn btn-half">OK</button>
+                <button id="btnNameCancel" class="btn btn-half">Cancel</button>
             </div>
         </div>
     </div>
@@ -185,13 +197,15 @@
         <div class="dialog">
             <p>Add a mapping</p>
             <div class="add-options">
-                <button class="btn add-opt" data-slot-kind="button">Capture button</button>
+                <button class="btn add-opt" data-slot-kind="button">Capture btn</button>
                 <button class="btn add-opt" data-slot-kind="dpad-up">D-pad Up</button>
                 <button class="btn add-opt" data-slot-kind="dpad-down">D-pad Down</button>
                 <button class="btn add-opt" data-slot-kind="dpad-left">D-pad Left</button>
                 <button class="btn add-opt" data-slot-kind="dpad-right">D-pad Right</button>
                 <button class="btn add-opt" data-slot-kind="trigger-lt">Trigger LT</button>
                 <button class="btn add-opt" data-slot-kind="trigger-rt">Trigger RT</button>
+                <button class="btn add-opt" data-slot-kind="stick">Capture stick</button>
+                <button class="btn add-opt" data-slot-kind="gesture">Record gesture</button>
             </div>
             <div class="dialog-buttons">
                 <button id="btnAddCancel" class="btn">Cancel</button>

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -24,7 +24,8 @@ var MapperManager = (function() {
     var deviceScanTimer = null; // Device tab auto-refresh interval
     var lastDevicesSig = "";    // last /devices result, to skip redundant renders
 
-    var DEVICE_KINDS = ["buttons", "longpress", "dpad", "dpad_longpress", "triggers", "triggers_longpress"];
+    var DEVICE_KINDS = ["buttons", "longpress", "dpad", "dpad_longpress", "triggers", "triggers_longpress",
+                        "stick_left", "stick_right", "gestures"];
 
     var _kbdKeys = null;
     function buildKeyboardKeys() {
@@ -386,7 +387,10 @@ var MapperManager = (function() {
                 { kind: "dpad",               label: "DPad" },
                 { kind: "dpad_longpress",     label: "DPad Long" },
                 { kind: "triggers",           label: "Trigger" },
-                { kind: "triggers_longpress", label: "Trig Long" }
+                { kind: "triggers_longpress", label: "Trig Long" },
+                { kind: "stick_left",         label: "L Stick" },
+                { kind: "stick_right",        label: "R Stick" },
+                { kind: "gestures",           label: "Gesture" }
             ];
 
             for (var s = 0; s < sectionList.length; s++) {
@@ -412,11 +416,21 @@ var MapperManager = (function() {
     function renderBindingRow(section, label, key, script) {
         var parsed = extractAction(script);
         var actionLabel = labelForAction(parsed) || parsed.id || script;
-        return '<div class="binding-row" data-section="' + escapeHtml(section) + '" data-key="' + escapeHtml(key) + '">'
+        var attrs = ' data-section="' + escapeHtml(section) + '" data-key="' + escapeHtml(key) + '"';
+        // Only a gesture carries a name the user chose, so only it can be renamed.
+        var rename = isGestureSection(section)
+            ? '<button class="binding-del binding-ren"' + attrs + '>Name</button>'
+            : '';
+        return '<div class="binding-row"' + attrs + '>'
             + '<span class="binding-slot">' + escapeHtml(label) + " " + escapeHtml(key) + '</span>'
             + '<span class="binding-action">' + escapeHtml(actionLabel) + '</span>'
-            + '<button class="binding-del" data-section="' + escapeHtml(section) + '" data-key="' + escapeHtml(key) + '">&#x2715;</button>'
+            + '<button class="binding-del"' + attrs + '>&#x2715;</button>'
+            + rename
             + '</div>';
+    }
+
+    function isGestureSection(section) {
+        return section && section.slice(-9) === ".gestures";
     }
 
     function extractAction(script) {
@@ -485,8 +499,12 @@ var MapperManager = (function() {
             return;
         }
         var kind = e.currentTarget.getAttribute("data-slot-kind");
-        if (kind === "button") {
+        if (kind === "button" || kind === "stick") {
             captureNewButton(false);
+            return;
+        }
+        if (kind === "gesture") {
+            recordGesture();
             return;
         }
         var slot = mapKindToSlot(kind);
@@ -574,10 +592,117 @@ var MapperManager = (function() {
                 slot = { kind: "dpad", key: dir };
             } else if (data.kind === "trigger") {
                 slot = { kind: "triggers", key: data.code === 10 ? "lt" : "rt" };
+            } else if (data.kind === "stick") {
+                var horizontal = (data.code === 0 || data.code === 3);
+                slot = {
+                    kind: (data.code === 0 || data.code === 1) ? "stick_left" : "stick_right",
+                    key: horizontal ? (data.value > 0 ? "right" : "left")
+                                    : (data.value > 0 ? "down" : "up")
+                };
             }
             if (!slot) { showMessage("unknown event", true); return; }
             pendingSlot = { section: devSection(slot.kind), key: slot.key };
             openActionPicker();
+        });
+    }
+
+    function recordGesture() {
+        var used = ini.sections["gestures"] || [];
+        var n = used.length + 1;
+        var name = "gesture" + n;
+        for (var i = 0; i < used.length; i++) {
+            if (used[i][0] === name) { n++; name = "gesture" + n; i = -1; }
+        }
+        if (!currentDeviceId) { showMessage("Add a device first", true); return; }
+        showMessage("Finding device...", false);
+        resolveDevicePath(currentDeviceId, function(devPath, err) {
+            if (!devPath) { showMessage(err || "Device not connected", true); return; }
+            startGestureRecord(devPath, name);
+        });
+    }
+
+    function startGestureRecord(devPath, name) {
+        showOverlay("captureOverlay");
+        getEl("captureMsg").innerHTML = "Make the gesture on the device";
+        getEl("captureHint").innerHTML = "Recording " + escapeHtml(name) + " on " + escapeHtml(devPath);
+
+        var url = "/record-gesture?device=" + encodeURIComponent(devPath) + "&timeout=12000";
+        captureXhrAbort = request("GET", url, null, function(text, err) {
+            captureXhrAbort = null;
+            hideOverlay("captureOverlay");
+            if (err) { showMessage("Record: " + err, true); return; }
+            var data;
+            try { data = JSON.parse(text); } catch (e) { showMessage("bad JSON", true); return; }
+            if (!data.ok) { showMessage(data.error || "record failed", true); return; }
+            askName("Name this gesture", name, function(chosen) {
+                var key = gestureName(chosen || name);
+                setValue("gestures", key, data.points);
+                pendingSlot = { section: devSection("gestures"), key: key };
+                openActionPicker();
+            });
+        });
+    }
+
+    // ---- Gesture names ----
+
+    var nameCallback = null;
+
+    function askName(title, current, cb) {
+        nameCallback = cb;
+        getEl("nameTitle").innerHTML = escapeHtml(title);
+        getEl("nameInput").value = current || "";
+        showOverlay("nameOverlay");
+    }
+
+    function closeName(value) {
+        hideOverlay("nameOverlay");
+        var cb = nameCallback;
+        nameCallback = null;
+        if (cb) cb(value);
+    }
+
+    function onNameOk() {
+        closeName(getEl("nameInput").value.replace(/^\s+|\s+$/g, ""));
+    }
+
+    // An ini key the parser will not choke on, and not one already taken.
+    function gestureName(typed) {
+        var base = typed.replace(/[=;#\[\]\r\n]/g, "").replace(/^\s+|\s+$/g, "");
+        if (!base) base = "gesture";
+        var out = base;
+        var n = 2;
+        while (gestureExists(out)) { out = base + " " + n; n++; }
+        return out;
+    }
+
+    // The daemon's parser folds case, so two names differing only in case are
+    // one gesture to it.
+    function gestureExists(name) {
+        var entries = ini.sections["gestures"] || [];
+        for (var i = 0; i < entries.length; i++) {
+            if (entries[i][0].toLowerCase() === name.toLowerCase()) return true;
+        }
+        return false;
+    }
+
+    function renameGesture(section, oldKey) {
+        askName("Rename gesture", oldKey, function(chosen) {
+            if (!chosen || chosen === oldKey) return;
+            var points = getValue("gestures", oldKey);
+            delValue("gestures", oldKey);
+            var key = gestureName(chosen);
+            if (points !== null) setValue("gestures", key, points);
+            // Every device binding this gesture has to follow the name.
+            for (var i = 0; i < ini.order.length; i++) {
+                var sec = ini.order[i];
+                if (!isGestureSection(sec)) continue;
+                var script = getValue(sec, oldKey);
+                if (script === null) continue;
+                delValue(sec, oldKey);
+                setValue(sec, key, script);
+            }
+            renderBindings();
+            showMessage("Renamed to " + key + " (unsaved)", false);
         });
     }
 
@@ -699,6 +824,11 @@ var MapperManager = (function() {
     function onBindingsListClick(e) {
         var target = e.target;
         if (!target) return;
+
+        if (target.className && target.className.indexOf("binding-ren") >= 0) {
+            renameGesture(target.getAttribute("data-section"), target.getAttribute("data-key"));
+            return;
+        }
 
         // Delete button takes priority over row-tap.
         if (target.className && target.className.indexOf("binding-del") >= 0) {
@@ -1007,7 +1137,9 @@ var MapperManager = (function() {
             if (err) { getEl("logsContent").innerHTML = escapeHtml("Error: " + err); return; }
             var lines = (text || "").split("\n");
             for (var i = 0; i < lines.length; i++) { lines[i] = formatLogLine(lines[i]); }
-            getEl("logsContent").innerHTML = escapeHtml(lines.join("\n")) || "(empty)";
+            var el = getEl("logsContent");
+            el.innerHTML = escapeHtml(lines.join("\n")) || "(empty)";
+            el.scrollTop = el.scrollHeight;
         });
     }
 
@@ -1038,6 +1170,8 @@ var MapperManager = (function() {
         getEl("btnLogsClose").addEventListener("click", closeLogs, false);
         getEl("btnSaveRaw").addEventListener("click", saveRawConfig, false);
         getEl("btnCaptureCancel").addEventListener("click", cancelCapture, false);
+        getEl("btnNameOk").addEventListener("click", onNameOk, false);
+        getEl("btnNameCancel").addEventListener("click", function() { closeName(null); }, false);
         getEl("btnActionCancel").addEventListener("click", function() {
             hideOverlay("actionOverlay"); pendingSlot = null; continuousCapture = false;
         }, false);
@@ -1140,17 +1274,21 @@ var MapperManager = (function() {
         document.body.style.overflow = "hidden";
     }
 
+    var BOOT_ATTEMPTS = 20;
+
     function bootstrapFetch(attempt) {
         attempt = attempt || 0;
         getJSON("/actions", function(data, err) {
-            if (err && attempt < 5) {
+            if (err && attempt < BOOT_ATTEMPTS) {
+                if (attempt === 1) showMessage("Waiting for the daemon...", false);
                 setTimeout(function() { bootstrapFetch(attempt + 1); }, 500);
                 return;
             }
             if (data && data.actions) actions = data.actions;
             request("GET", "/config", null, function(text, err2) {
                 if (err2) {
-                    if (attempt < 5) {
+                    if (attempt < BOOT_ATTEMPTS) {
+                        if (attempt === 1) showMessage("Waiting for the daemon...", false);
                         setTimeout(function() { bootstrapFetch(attempt + 1); }, 500);
                         return;
                     }

--- a/illusion/MapperManager/style.css
+++ b/illusion/MapperManager/style.css
@@ -279,6 +279,16 @@ html, body {
 
 .binding-del:active { background: #000; color: #fff; }
 
+.binding-ren { margin-right: 10px; font-size: 26px; }
+
+/* detail-input floats right to sit beside a label; here it is the whole row. */
+#nameInput {
+    float: none;
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
 .binding-empty {
     padding: 30px 0;
     text-align: center;
@@ -431,10 +441,21 @@ html, body {
 }
 
 .dialog-tall { top: 6%; height: 88%; overflow: hidden; padding-bottom: 110px; }
-.dialog-wide { left: 2%; width: 96%; padding-bottom: 28px; }
+.dialog-wide { left: 2%; width: 96%; }
+
+#logsActions {
+    position: absolute;
+    left: 28px;
+    right: 28px;
+    bottom: 28px;
+}
 
 .logs-content {
-    height: 940px;
+    position: absolute;
+    left: 28px;
+    right: 28px;
+    top: 100px;
+    bottom: 132px;
     overflow: auto;
     font-family: monospace;
     font-size: 22px;
@@ -444,7 +465,6 @@ html, body {
     text-align: left;
     border: 2px solid #000;
     padding: 12px;
-    margin-bottom: 16px;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
 }
@@ -547,7 +567,10 @@ html, body {
 
 .action-item:active .action-id { color: #ccc; }
 
-.add-options { margin-bottom: 14px; }
+.add-options { margin-bottom: 14px; overflow: hidden; }
+/* Two per row: the list outgrew the screen once sticks and swipes joined it,
+   and scrolling a dialog on eink is worse than a narrower button. */
+.add-options .add-opt { float: left; width: 48%; margin: 0 1% 10px; }
 
 /* ---- Raw config ---- */
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,9 @@ pub struct DeviceConfig {
     pub dpad_longpress_mappings: HashMap<DpadDirection, String>,
     pub trigger_mappings: HashMap<Trigger, String>,
     pub trigger_longpress_mappings: HashMap<Trigger, String>,
+    pub stick_left_mappings: HashMap<DpadDirection, String>,
+    pub stick_right_mappings: HashMap<DpadDirection, String>,
+    pub gesture_mappings: HashMap<String, String>,
 }
 
 const KEY_SH: &str = "/mnt/us/kindle-button-mapper/scripts/key.sh";
@@ -79,6 +82,9 @@ impl DeviceConfig {
             && self.dpad_longpress_mappings.is_empty()
             && self.trigger_mappings.is_empty()
             && self.trigger_longpress_mappings.is_empty()
+            && self.stick_left_mappings.is_empty()
+            && self.stick_right_mappings.is_empty()
+            && self.gesture_mappings.is_empty()
     }
 
     #[cfg(test)]
@@ -101,6 +107,9 @@ impl DeviceConfig {
             dpad_longpress_mappings: HashMap::new(),
             trigger_mappings: HashMap::new(),
             trigger_longpress_mappings: HashMap::new(),
+            stick_left_mappings: HashMap::new(),
+            stick_right_mappings: HashMap::new(),
+            gesture_mappings: HashMap::new(),
         }
     }
 }
@@ -113,6 +122,10 @@ pub struct Config {
     pub repeat_ms: u64,
     pub log_buttons: bool,
     pub keep_awake: bool,
+    pub stick_deadzone: i32,
+    pub gesture_min_percent: i32,
+    pub gesture_tolerance: f32,
+    pub gesture_templates: Vec<(String, Vec<crate::gesture::Point>)>,
     pub on_connect: Option<String>,
     pub on_disconnect: Option<String>,
 }
@@ -126,6 +139,10 @@ impl Default for Config {
             repeat_ms: 100,
             log_buttons: false,
             keep_awake: true,
+            stick_deadzone: 50,
+            gesture_min_percent: 15,
+            gesture_tolerance: 0.30,
+            gesture_templates: Vec::new(),
             on_connect: None,
             on_disconnect: None,
         }
@@ -174,8 +191,22 @@ impl Config {
             if let Some(v) = get(s, "repeat_ms") { config.repeat_ms = v.parse().unwrap_or(config.repeat_ms); }
             if let Some(v) = get(s, "log_buttons") { config.log_buttons = parse_bool(v); }
             if let Some(v) = get(s, "keep_awake") { config.keep_awake = parse_bool(v); }
+            if let Some(v) = get(s, "stick_deadzone") { config.stick_deadzone = v.parse().unwrap_or(config.stick_deadzone); }
+            if let Some(v) = get(s, "gesture_min_percent") { config.gesture_min_percent = v.parse().unwrap_or(config.gesture_min_percent); }
+            if let Some(v) = get(s, "gesture_tolerance") { config.gesture_tolerance = v.parse().unwrap_or(config.gesture_tolerance); }
             config.on_connect = get(s, "on_connect").filter(|v| !v.is_empty()).map(String::from);
             config.on_disconnect = get(s, "on_disconnect").filter(|v| !v.is_empty()).map(String::from);
+        }
+
+        if let Some(sec) = map.get("gestures") {
+            for (name, points) in sec {
+                if let Some(points) = points {
+                    let parsed = crate::gesture::from_string(points);
+                    if !parsed.is_empty() {
+                        config.gesture_templates.push((name.clone(), parsed));
+                    }
+                }
+            }
         }
 
         // First pass: collect device IDs from [device.NAME] sections, ordered by appearance.
@@ -234,6 +265,15 @@ impl Config {
                 Some("triggers") => fill_trigger_map(entries, &mut dev.trigger_mappings),
                 Some("triggers_longpress") => {
                     fill_trigger_map(entries, &mut dev.trigger_longpress_mappings)
+                }
+                Some("stick_left") => fill_dpad_map(entries, &mut dev.stick_left_mappings),
+                Some("stick_right") => fill_dpad_map(entries, &mut dev.stick_right_mappings),
+                Some("gestures") => {
+                    for (k, v) in entries {
+                        if let Some(v) = v {
+                            dev.gesture_mappings.insert(k.clone(), v.clone());
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -397,5 +437,36 @@ mod tests {
         assert!(!dev.is_unmapped());
         assert!(dev.dpad_mappings.is_empty());
         assert_eq!(dev.mappings[&Key::new(304)], "/mnt/us/mine.sh");
+    }
+}
+
+#[cfg(test)]
+mod gesture_config_tests {
+    use super::*;
+
+    #[test]
+    fn a_gesture_survives_a_round_trip_through_the_ini_parser() {
+        let pts: Vec<crate::gesture::Point> =
+            (0..32).map(|i| (i as f32 / 31.0, 0.5)).collect();
+        // A name the user typed, not a generated one.
+        let body = format!(
+            "[settings]\nlog_buttons = true\n\n[gestures]\nPage Next = {}\n\n\
+             [device.pad]\nname = Pad\nuniq = AA:BB\n\n\
+             [device.pad.gestures]\nPage Next = /bin/true\n",
+            crate::gesture::to_string(&pts)
+        );
+        let path = std::env::temp_dir().join("kbm_gesture_roundtrip.ini");
+        std::fs::write(&path, body).unwrap();
+
+        let cfg = Config::load(&path).expect("config loads");
+        let (name, loaded) = cfg.gesture_templates.first().expect("template present");
+        assert_eq!(loaded.len(), pts.len(), "every point must survive the parser");
+        assert!(crate::gesture::distance(loaded, &pts) < 0.01);
+
+        // Whatever the parser does to the spelling, both halves must agree or
+        // the binding never fires.
+        let dev = cfg.devices.iter().find(|d| d.id == "pad").unwrap();
+        assert!(dev.gesture_mappings.contains_key(name), "template {:?} has no binding", name);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/gesture.rs
+++ b/src/gesture.rs
@@ -1,0 +1,252 @@
+const SAMPLES: usize = 32;
+
+pub type Point = (f32, f32);
+
+pub fn normalize(path: &[Point]) -> Vec<Point> {
+    let path = resample(path, SAMPLES);
+    let (cx, cy) = centroid(&path);
+    let centred: Vec<Point> = path.iter().map(|p| (p.0 - cx, p.1 - cy)).collect();
+    let scale = centred
+        .iter()
+        .fold(0.0f32, |m, p| m.max(p.0.abs()).max(p.1.abs()));
+    if scale <= f32::EPSILON {
+        return centred;
+    }
+    centred.iter().map(|p| (p.0 / scale, p.1 / scale)).collect()
+}
+
+pub fn distance(a: &[Point], b: &[Point]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return f32::MAX;
+    }
+    let sum: f32 = a
+        .iter()
+        .zip(b)
+        .map(|(p, q)| ((p.0 - q.0).powi(2) + (p.1 - q.1).powi(2)).sqrt())
+        .sum();
+    sum / a.len() as f32
+}
+
+/// Closest template and how far off it is, tolerance not applied.
+pub fn nearest<'a>(stroke: &[Point], templates: &'a [(String, Vec<Point>)]) -> Option<(&'a str, f32)> {
+    let stroke = normalize(stroke);
+    let mut best: Option<(&str, f32)> = None;
+    for (name, points) in templates {
+        let d = distance(&stroke, points);
+        if best.is_none_or(|(_, bd)| d < bd) {
+            best = Some((name.as_str(), d));
+        }
+    }
+    best
+}
+
+pub fn travel(path: &[Point]) -> f32 {
+    match (path.first(), path.last()) {
+        (Some(a), Some(b)) => ((b.0 - a.0).powi(2) + (b.1 - a.1).powi(2)).sqrt(),
+        _ => 0.0,
+    }
+}
+
+pub fn to_string(points: &[Point]) -> String {
+    points
+        .iter()
+        .map(|p| format!("{:.3},{:.3}", p.0, p.1))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub fn from_string(s: &str) -> Vec<Point> {
+    s.split([' ', ';'])
+        .filter_map(|pair| {
+            let (x, y) = pair.trim().split_once(',')?;
+            Some((x.trim().parse().ok()?, y.trim().parse().ok()?))
+        })
+        .collect()
+}
+
+/// Accumulates one contact. A touch report carries the button and the
+/// coordinates in the same packet, and the button arrives first, so a point
+/// taken at press time is the previous contact's. Points are collected on the
+/// report boundary instead: never half a sample, never a leftover position.
+#[derive(Default)]
+pub struct Stroke {
+    pos: Point,
+    down: bool,
+    points: Vec<Point>,
+}
+
+impl Stroke {
+    pub fn axis(&mut self, horizontal: bool, pct: i32) {
+        if horizontal {
+            self.pos.0 = pct as f32;
+        } else {
+            self.pos.1 = pct as f32;
+        }
+    }
+
+    pub fn press(&mut self) {
+        self.down = true;
+        self.points.clear();
+    }
+
+    pub fn sync(&mut self) {
+        if self.down {
+            self.points.push(self.pos);
+        }
+    }
+
+    /// The finished path, or None if no press opened it.
+    pub fn release(&mut self) -> Option<Vec<Point>> {
+        if !self.down {
+            return None;
+        }
+        self.down = false;
+        Some(std::mem::take(&mut self.points))
+    }
+}
+
+fn centroid(path: &[Point]) -> Point {
+    let n = path.len() as f32;
+    let (sx, sy) = path.iter().fold((0.0, 0.0), |a, p| (a.0 + p.0, a.1 + p.1));
+    (sx / n, sy / n)
+}
+
+fn resample(path: &[Point], n: usize) -> Vec<Point> {
+    if path.len() < 2 {
+        return vec![*path.first().unwrap_or(&(0.0, 0.0)); n];
+    }
+    let total: f32 = path.windows(2).map(|w| dist(w[0], w[1])).sum();
+    if total <= f32::EPSILON {
+        return vec![path[0]; n];
+    }
+    let step = total / (n - 1) as f32;
+
+    let mut out = vec![path[0]];
+    let mut acc = 0.0;
+    let mut i = 1;
+    let mut prev = path[0];
+    while i < path.len() && out.len() < n {
+        let d = dist(prev, path[i]);
+        if acc + d >= step && d > f32::EPSILON {
+            let t = (step - acc) / d;
+            let p = (
+                prev.0 + t * (path[i].0 - prev.0),
+                prev.1 + t * (path[i].1 - prev.1),
+            );
+            out.push(p);
+            prev = p;
+            acc = 0.0;
+        } else {
+            acc += d;
+            prev = path[i];
+            i += 1;
+        }
+    }
+    while out.len() < n {
+        out.push(*path.last().unwrap());
+    }
+    out
+}
+
+fn dist(a: Point, b: Point) -> f32 {
+    ((b.0 - a.0).powi(2) + (b.1 - a.1).powi(2)).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn best<'a>(stroke: &[Point], t: &'a [(String, Vec<Point>)], tol: f32) -> Option<&'a str> {
+        nearest(stroke, t).filter(|(_, d)| *d <= tol).map(|(n, _)| n)
+    }
+
+    fn line(from: Point, to: Point, steps: usize) -> Vec<Point> {
+        (0..=steps)
+            .map(|i| {
+                let t = i as f32 / steps as f32;
+                (from.0 + t * (to.0 - from.0), from.1 + t * (to.1 - from.1))
+            })
+            .collect()
+    }
+
+    fn templates() -> Vec<(String, Vec<Point>)> {
+        vec![
+            ("swipe_left".into(), normalize(&line((80.0, 50.0), (20.0, 50.0), 20))),
+            ("swipe_down".into(), normalize(&line((50.0, 20.0), (50.0, 80.0), 20))),
+            ("check".into(), {
+                let mut p = line((20.0, 50.0), (40.0, 70.0), 10);
+                p.extend(line((40.0, 70.0), (80.0, 20.0), 10));
+                normalize(&p)
+            }),
+        ]
+    }
+
+    #[test]
+    fn the_same_movement_matches_whatever_its_size_or_speed() {
+        let t = templates();
+        let small = line((60.0, 50.0), (45.0, 50.0), 3);
+        assert_eq!(best(&small, &t, 0.3), Some("swipe_left"));
+        let offset = line((90.0, 10.0), (30.0, 12.0), 40);
+        assert_eq!(best(&offset, &t, 0.3), Some("swipe_left"));
+    }
+
+    #[test]
+    fn a_different_movement_does_not_match() {
+        let t = templates();
+        assert_eq!(
+            best(&line((50.0, 20.0), (50.0, 80.0), 20), &t, 0.3),
+            Some("swipe_down")
+        );
+        let mut circle = Vec::new();
+        for i in 0..40 {
+            let a = i as f32 / 40.0 * std::f32::consts::TAU;
+            circle.push((50.0 + 20.0 * a.cos(), 50.0 + 20.0 * a.sin()));
+        }
+        assert_eq!(best(&circle, &t, 0.15), None);
+    }
+
+    #[test]
+    fn a_two_part_shape_matches_itself_and_not_a_straight_line() {
+        let t = templates();
+        let mut drawn = line((25.0, 55.0), (45.0, 72.0), 6);
+        drawn.extend(line((45.0, 72.0), (85.0, 25.0), 6));
+        assert_eq!(best(&drawn, &t, 0.3), Some("check"));
+    }
+
+    #[test]
+    fn a_tap_travels_nowhere() {
+        assert!(travel(&line((50.0, 50.0), (50.0, 50.0), 4)) < 0.01);
+        assert!(travel(&line((20.0, 50.0), (80.0, 50.0), 4)) > 50.0);
+    }
+
+    #[test]
+    fn a_stroke_starts_where_the_finger_lands_not_where_the_last_one_ended() {
+        let mut s = Stroke::default();
+        // A previous contact left the position at the bottom of the pad.
+        s.axis(false, 90);
+        s.axis(true, 10);
+
+        // Press and coordinates arrive in one report, button first.
+        s.press();
+        s.axis(true, 50);
+        s.axis(false, -80);
+        s.sync();
+        // Only Y changes, so the device does not resend X.
+        s.axis(false, 0);
+        s.sync();
+        s.axis(false, 80);
+        s.sync();
+
+        let path = s.release().expect("press opened it");
+        assert_eq!(path, vec![(50.0, -80.0), (50.0, 0.0), (50.0, 80.0)]);
+        assert!(s.release().is_none());
+    }
+
+    #[test]
+    fn points_survive_a_round_trip_through_the_config() {
+        let p = normalize(&line((10.0, 10.0), (90.0, 90.0), 8));
+        let back = from_string(&to_string(&p));
+        assert_eq!(back.len(), p.len());
+        assert!(distance(&p, &back) < 0.01);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,11 @@ mod mapper;
 mod pause;
 mod reload;
 mod vkeyboard;
+mod gesture;
 mod waf_helper;
 
 use config::Config;
+use std::collections::HashMap;
 use evdev::InputEventKind;
 use input::InputHandler;
 use layout::LayoutOverride;
@@ -78,8 +80,9 @@ fn main() {
         env!("BUILD_SHA")
     );
     info!(
-        "Config: devices={}, debounce={}ms, long_press={}ms, repeat={}ms",
+        "Config: devices={}, gestures={}, debounce={}ms, long_press={}ms, repeat={}ms",
         config.devices.len(),
+        config.gesture_templates.len(),
         config.debounce_ms,
         config.long_press_ms,
         config.repeat_ms,
@@ -109,15 +112,7 @@ fn main() {
         .filter(|l| !l.is_empty())
         .and_then(LayoutOverride::new);
 
-    let settings = WorkerSettings {
-        debounce_ms: config.debounce_ms,
-        long_press_ms: config.long_press_ms,
-        repeat_ms: config.repeat_ms,
-        log_buttons: config.log_buttons,
-        keep_awake: config.keep_awake,
-        on_connect: config.on_connect.clone(),
-        on_disconnect: config.on_disconnect.clone(),
-    };
+    let settings = WorkerSettings::from_config(&config);
     for device in config.devices {
         if reload::claim(&device.id) {
             spawn_worker(device, settings.clone());
@@ -145,14 +140,36 @@ fn spawn_worker(device: config::DeviceConfig, settings: WorkerSettings) {
 }
 
 #[derive(Clone)]
-struct WorkerSettings {
+pub(crate) struct WorkerSettings {
     debounce_ms: u64,
     long_press_ms: u64,
     repeat_ms: u64,
     log_buttons: bool,
+    stick_deadzone: i32,
+    gesture_min_percent: i32,
+    gesture_tolerance: f32,
+    gesture_templates: Vec<(String, Vec<gesture::Point>)>,
     keep_awake: bool,
     on_connect: Option<String>,
     on_disconnect: Option<String>,
+}
+
+impl WorkerSettings {
+    pub(crate) fn from_config(c: &config::Config) -> Self {
+        Self {
+            debounce_ms: c.debounce_ms,
+            long_press_ms: c.long_press_ms,
+            repeat_ms: c.repeat_ms,
+            log_buttons: c.log_buttons,
+            stick_deadzone: c.stick_deadzone,
+            gesture_min_percent: c.gesture_min_percent,
+            gesture_tolerance: c.gesture_tolerance,
+            gesture_templates: c.gesture_templates.clone(),
+            keep_awake: c.keep_awake,
+            on_connect: c.on_connect.clone(),
+            on_disconnect: c.on_disconnect.clone(),
+        }
+    }
 }
 
 /// Why the event loop gave the device back.
@@ -182,17 +199,8 @@ fn park_until_reconfigured(id: &str, generation: &mut u64) -> config::DeviceConf
     }
 }
 
-fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
-    let build = |cfg: &config::DeviceConfig| {
-        Mapper::new(
-            cfg,
-            settings.debounce_ms,
-            settings.long_press_ms,
-            settings.repeat_ms,
-            settings.log_buttons,
-        )
-    };
-    let mut mapper = build(&cfg);
+fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
+    let mut mapper = Mapper::new(&cfg, &settings);
     let mut generation = reload::generation();
 
     loop {
@@ -205,7 +213,7 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                 if cfg.is_unmapped() {
                     if gamepad {
                         cfg.apply_default_layout();
-                        mapper = build(&cfg);
+                        mapper = Mapper::new(&cfg, &settings);
                     } else if cfg.keyboard_layout.is_none() {
                         info!(
                             "[{}] no mappings and not a gamepad — leaving it alone until something is mapped",
@@ -214,7 +222,7 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                         // Dropping the device releases the grab.
                         drop(device);
                         cfg = park_until_reconfigured(&cfg.id, &mut generation);
-                        mapper = build(&cfg);
+                        mapper = Mapper::new(&cfg, &settings);
                         continue;
                     }
                 }
@@ -243,7 +251,7 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                         cfg.id
                     );
                     cfg.passthrough = false;
-                    mapper = build(&cfg);
+                    mapper = Mapper::new(&cfg, &settings);
                 }
                 if grab && cfg.passthrough && !vkeyboard::available() {
                     warn!(
@@ -266,11 +274,11 @@ fn device_worker(mut cfg: config::DeviceConfig, settings: WorkerSettings) {
                     execute_script(script);
                 }
                 match run_event_loop(&mut device, &mut mapper, grab, gamepad,
-                    &mut cfg, &mut generation, &settings) {
+                    &mut cfg, &mut generation, &mut settings) {
                     Exit::Removed => {
                         drop(device);
                         cfg = park_until_reconfigured(&cfg.id, &mut generation);
-                        mapper = build(&cfg);
+                        mapper = Mapper::new(&cfg, &settings);
                         continue;
                     }
                     Exit::Disconnected(e) => {
@@ -298,10 +306,16 @@ fn run_event_loop(
     gamepad: bool,
     cfg: &mut config::DeviceConfig,
     generation: &mut u64,
-    settings: &WorkerSettings,
+    settings: &mut WorkerSettings,
 ) -> Exit {
     // Non-blocking + poll so we can notice a capture pause while idle.
     set_nonblocking(device.as_raw_fd());
+    let ranges = stick_ranges(device);
+    // ABS_X/ABS_Y mean a contact on a touch device and a stick on a pad, so
+    // the device decides which once, not every event.
+    let touch_device = device
+        .supported_keys()
+        .is_some_and(|k| k.contains(evdev::Key::BTN_TOUCH));
     let mut grab = grab;
     let mut grabbed = grab;
 
@@ -319,13 +333,10 @@ fn run_event_loop(
             match reload::device_config(&cfg.id) {
                 Some(fresh) => {
                     info!("[{}] applying reloaded mappings", cfg.id);
-                    *mapper = Mapper::new(
-                        &fresh,
-                        settings.debounce_ms,
-                        settings.long_press_ms,
-                        settings.repeat_ms,
-                        settings.log_buttons,
-                    );
+                    if let Some(globals) = reload::settings() {
+                        *settings = globals;
+                    }
+                    *mapper = Mapper::new(&fresh, settings);
                     // Switching who owns the device has to bite now rather
                     // than on the next reconnect, or the toggle looks broken.
                     let want = effective_grab(&fresh, gamepad);
@@ -389,6 +400,11 @@ fn run_event_loop(
         let mut activity = false;
         for event in events {
             match event.kind() {
+                InputEventKind::Synchronization(_) => mapper.handle_sync(),
+                InputEventKind::Key(key) if key.code() == 330 => {  // BTN_TOUCH
+                    activity = true;
+                    mapper.handle_touch(event.value() == 1);
+                }
                 InputEventKind::Key(key) => {
                     activity = true;
                     match event.value() {
@@ -410,6 +426,18 @@ fn run_event_loop(
                         9 | 10 => {
                             activity = true;
                             mapper.handle_trigger(code, event.value());
+                        }
+                        0 | 1 if touch_device => {
+                            activity = true;
+                            mapper.handle_touch_move(code == 0, stick_percent(&ranges, code, event.value()));
+                        }
+                        0 | 1 | 3 | 4 => {
+                            activity = true;
+                            mapper.handle_stick(code, stick_percent(&ranges, code, event.value()));
+                        }
+                        53 | 54 => {
+                            activity = true;
+                            mapper.handle_touch_move(code == 53, stick_percent(&ranges, code, event.value()));
                         }
                         _ => {}
                     }
@@ -434,6 +462,29 @@ fn run_event_loop(
 /// since grabbing a keyboard would swallow every key nothing maps.
 fn effective_grab(cfg: &config::DeviceConfig, gamepad: bool) -> bool {
     cfg.grab && (cfg.grab_explicit || gamepad)
+}
+
+/// Centre and half-travel per axis; pads disagree on range, the mapper sees a percentage.
+fn stick_ranges(dev: &evdev::Device) -> HashMap<u16, (i32, i32)> {
+    let states = match dev.get_abs_state() {
+        Ok(s) => s,
+        Err(_) => return HashMap::new(),
+    };
+    [0u16, 1, 3, 4, 53, 54]
+        .iter()
+        .filter_map(|&code| {
+            let i = states.get(code as usize)?;
+            let half = ((i.maximum - i.minimum) / 2).max(1);
+            Some((code, ((i.minimum + i.maximum) / 2, half)))
+        })
+        .collect()
+}
+
+fn stick_percent(ranges: &HashMap<u16, (i32, i32)>, code: u16, value: i32) -> i32 {
+    match ranges.get(&code) {
+        Some((centre, half)) => ((value - centre) * 100 / half).clamp(-100, 100),
+        None => 0,
+    }
 }
 
 fn is_gamepad(dev: &evdev::Device) -> bool {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -13,6 +13,15 @@ pub struct Mapper {
     dpad_longpress_mappings: HashMap<DpadDirection, String>,
     trigger_mappings: HashMap<Trigger, String>,
     trigger_longpress_mappings: HashMap<Trigger, String>,
+    stick_left_mappings: HashMap<DpadDirection, String>,
+    stick_right_mappings: HashMap<DpadDirection, String>,
+    stick_deadzone: i32,
+    stick_pushed: HashMap<u16, bool>,
+    gesture_mappings: HashMap<String, String>,
+    gesture_min_percent: i32,
+    gesture_tolerance: f32,
+    gesture_templates: Vec<(String, Vec<crate::gesture::Point>)>,
+    stroke: crate::gesture::Stroke,
     debounce_ms: u64,
     long_press_ms: u64,
     repeat_ms: u64,
@@ -37,13 +46,7 @@ pub struct Mapper {
 }
 
 impl Mapper {
-    pub fn new(
-        cfg: &DeviceConfig,
-        debounce_ms: u64,
-        long_press_ms: u64,
-        repeat_ms: u64,
-        log_buttons: bool,
-    ) -> Self {
+    pub fn new(cfg: &DeviceConfig, s: &crate::WorkerSettings) -> Self {
         Self {
             mappings: cfg.mappings.clone(),
             long_press_mappings: cfg.long_press_mappings.clone(),
@@ -51,10 +54,19 @@ impl Mapper {
             dpad_longpress_mappings: cfg.dpad_longpress_mappings.clone(),
             trigger_mappings: cfg.trigger_mappings.clone(),
             trigger_longpress_mappings: cfg.trigger_longpress_mappings.clone(),
-            debounce_ms,
-            long_press_ms,
-            repeat_ms,
-            log_buttons,
+            stick_left_mappings: cfg.stick_left_mappings.clone(),
+            stick_right_mappings: cfg.stick_right_mappings.clone(),
+            stick_deadzone: s.stick_deadzone,
+            stick_pushed: HashMap::new(),
+            gesture_mappings: cfg.gesture_mappings.clone(),
+            gesture_min_percent: s.gesture_min_percent,
+            gesture_tolerance: s.gesture_tolerance,
+            gesture_templates: s.gesture_templates.clone(),
+            stroke: crate::gesture::Stroke::default(),
+            debounce_ms: s.debounce_ms,
+            long_press_ms: s.long_press_ms,
+            repeat_ms: s.repeat_ms,
+            log_buttons: s.log_buttons,
             passthrough: cfg.passthrough,
             last_press: HashMap::new(),
             press_start: HashMap::new(),
@@ -313,6 +325,73 @@ impl Mapper {
     /// Brake (code 10): LT - value 0 (released) to 1023 (fully pressed)
     ///
     /// Handles controllers that send press-release-press cycles for auto-repeat.
+    pub fn handle_touch(&mut self, down: bool) {
+        if down {
+            self.stroke.press();
+            return;
+        }
+        let path = match self.stroke.release() {
+            Some(p) => p,
+            None => return,
+        };
+        if crate::gesture::travel(&path) < self.gesture_min_percent as f32 {
+            return;
+        }
+        let name = match crate::gesture::nearest(&path, &self.gesture_templates) {
+            Some((n, d)) if d <= self.gesture_tolerance => n.to_string(),
+            Some((n, d)) => {
+                info!("Gesture: no match (nearest '{}' at {:.2}, tolerance {:.2})", n, d, self.gesture_tolerance);
+                return;
+            }
+            None => {
+                info!("Gesture: no match (no gestures recorded)");
+                return;
+            }
+        };
+        let script = self.gesture_mappings.get(&name).cloned();
+        info!("Gesture '{}' -> {}", name, script.as_deref().unwrap_or("[unmapped]"));
+        if let Some(script) = script {
+            execute_script(&script);
+        }
+    }
+
+    pub fn handle_touch_move(&mut self, horizontal: bool, pct: i32) {
+        self.stroke.axis(horizontal, pct);
+    }
+
+    /// End of an input report. Contact position is sampled here.
+    pub fn handle_sync(&mut self) {
+        self.stroke.sync();
+    }
+
+    pub fn handle_stick(&mut self, axis: u16, pct: i32) {
+        let (mappings, stick, horizontal) = match axis {
+            0 | 1 => (&self.stick_left_mappings, "left", axis == 0),
+            3 | 4 => (&self.stick_right_mappings, "right", axis == 3),
+            _ => return,
+        };
+        if pct.abs() < self.stick_deadzone {
+            self.stick_pushed.insert(axis, false);
+            return;
+        }
+        let dir = match (horizontal, pct > 0) {
+            (true, false) => DpadDirection::Left,
+            (true, true) => DpadDirection::Right,
+            (false, false) => DpadDirection::Up,
+            (false, true) => DpadDirection::Down,
+        };
+        let script = mappings.get(&dir).cloned();
+        if self.stick_pushed.insert(axis, true) == Some(true) {
+            return;
+        }
+        if self.log_buttons {
+            info!("Stick {}: {:?} -> {}", stick, dir, script.as_deref().unwrap_or("[unmapped]"));
+        }
+        if let Some(script) = script {
+            execute_script(&script);
+        }
+    }
+
     pub fn handle_trigger(&mut self, axis: u16, value: i32) {
         let trigger = match axis {
             9 => Trigger::RT,   // Gas = Right Trigger
@@ -410,6 +489,12 @@ fn execute_script(script: &str) {
 
 #[cfg(test)]
 mod tests {
+    fn test_settings() -> crate::WorkerSettings {
+        let mut s = crate::WorkerSettings::from_config(&crate::config::Config::default());
+        s.debounce_ms = 0;
+        s
+    }
+
     use super::*;
     use crate::config::DeviceConfig;
 
@@ -419,7 +504,7 @@ mod tests {
         for code in mapped {
             cfg.mappings.insert(Key::new(*code), "/bin/true".into());
         }
-        Mapper::new(&cfg, 0, 500, 100, false)
+        Mapper::new(&cfg, &test_settings())
     }
 
     #[test]
@@ -439,11 +524,32 @@ mod tests {
     }
 
     #[test]
+    fn a_stick_fires_once_per_push_and_re_arms_at_centre() {
+        let mut m = Mapper::new(&DeviceConfig::for_test("dev"), &test_settings());
+
+        m.handle_stick(0, 10); // inside the deadzone, nothing to do
+        assert_eq!(m.stick_pushed.get(&0).copied(), Some(false));
+
+        m.handle_stick(0, 80); // pushed over
+        assert_eq!(m.stick_pushed.get(&0).copied(), Some(true));
+
+        m.handle_stick(0, 95); // held over, must not fire again
+        assert_eq!(m.stick_pushed.get(&0).copied(), Some(true));
+
+        m.handle_stick(0, 0); // back to centre, armed again
+        assert_eq!(m.stick_pushed.get(&0).copied(), Some(false));
+
+        m.handle_stick(1, -70);
+        assert_eq!(m.stick_pushed.get(&1).copied(), Some(true));
+        assert_eq!(m.stick_pushed.get(&0).copied(), Some(false));
+    }
+
+    #[test]
     fn a_long_press_mapping_also_claims_the_key() {
         let mut cfg = DeviceConfig::for_test("dev");
         cfg.passthrough = true;
         cfg.long_press_mappings.insert(Key::new(30), "/bin/true".into());
-        let m = Mapper::new(&cfg, 0, 500, 100, false);
+        let m = Mapper::new(&cfg, &test_settings());
         assert!(!m.relay(Key::new(30), 1));
     }
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -16,6 +16,9 @@ static REQUESTED: AtomicBool = AtomicBool::new(false);
 /// Bumped once per applied reload. Workers compare against their own copy.
 static GENERATION: AtomicU64 = AtomicU64::new(0);
 static DEVICES: OnceLock<Mutex<Vec<DeviceConfig>>> = OnceLock::new();
+/// The `[settings]` and `[gestures]` half of the file, so a reload refreshes
+/// them too instead of every worker keeping its startup copy forever.
+static SETTINGS: Mutex<Option<crate::WorkerSettings>> = Mutex::new(None);
 /// Device ids that already have a worker. Only grows, so a device removed and
 /// re-added does not end up with two threads fighting over the same node.
 static WATCHED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -47,6 +50,13 @@ pub fn generation() -> u64 {
 
 pub fn publish(config: &Config) {
     *devices().lock().unwrap_or_else(|p| p.into_inner()) = config.devices.clone();
+    *SETTINGS.lock().unwrap_or_else(|p| p.into_inner()) =
+        Some(crate::WorkerSettings::from_config(config));
+}
+
+/// The global settings as of the last reload.
+pub fn settings() -> Option<crate::WorkerSettings> {
+    SETTINGS.lock().unwrap_or_else(|p| p.into_inner()).clone()
 }
 
 /// The device's current config, or None if it was removed from the file.
@@ -87,5 +97,26 @@ pub fn poll(config_path: &str) -> Vec<DeviceConfig> {
             warn!("Reload failed, keeping the running config: {}", e);
             Vec::new()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_reload_refreshes_the_gestures_workers_read() {
+        let mut cfg = Config::default();
+        publish(&cfg);
+        assert!(settings().expect("published").gesture_templates.is_empty());
+
+        cfg.gesture_templates
+            .push(("flick".into(), vec![(0.0, 0.0), (1.0, 1.0)]));
+        cfg.gesture_tolerance = 0.42;
+        publish(&cfg);
+
+        let s = settings().expect("published");
+        assert_eq!(s.gesture_templates.len(), 1);
+        assert_eq!(s.gesture_tolerance, 0.42);
     }
 }

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -120,6 +120,7 @@ fn route(method: &str, path: &str, body: &str, config_path: &str) -> (u16, Strin
         ("GET", "/actions") => (200, actions_json()),
         ("GET", "/layouts") => (200, layouts_json()),
         ("GET", "/capture") => capture(&query),
+        ("GET", "/record-gesture") => record_gesture(&query),
         ("POST", "/reload") => reload_daemon(),
         ("POST", "/stop") => stop_daemon(),
         ("POST", "/start") => start_daemon(),
@@ -377,6 +378,115 @@ fn logs_text() -> String {
     }
 }
 
+fn record_gesture(query: &std::collections::HashMap<String, String>) -> (u16, String) {
+    let lock = match CAPTURE_LOCK.try_lock() {
+        Ok(g) => g,
+        Err(_) => return (200, json_err("capture already running")),
+    };
+    let path = match query.get("device") {
+        Some(p) if !p.is_empty() => p.clone(),
+        _ => return (200, json_err("missing device param")),
+    };
+    let timeout_ms: u64 = query
+        .get("timeout")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10000)
+        .min(20000);
+
+    let _pause = PauseGuard;
+    let _ = crate::pause::begin();
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mut device = match evdev::Device::open(&path) {
+        Ok(d) => d,
+        Err(e) => {
+            drop(lock);
+            return (200, json_err(&format!("open {}: {}", path, e)));
+        }
+    };
+
+    let ranges = axis_ranges(&device);
+    use nix::libc;
+    use std::os::unix::io::AsRawFd;
+    unsafe {
+        let fd = device.as_raw_fd();
+        let flags = libc::fcntl(fd, libc::F_GETFL, 0);
+        libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+    }
+
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    let mut stroke = crate::gesture::Stroke::default();
+
+    while Instant::now() < deadline {
+        let events = match device.fetch_events() {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(e) => {
+                drop(lock);
+                return (200, json_err(&format!("read: {}", e)));
+            }
+        };
+        for ev in events {
+            match ev.kind() {
+                InputEventKind::Synchronization(_) => stroke.sync(),
+                InputEventKind::Key(k) if k.code() == 330 => {
+                    if ev.value() == 1 {
+                        stroke.press();
+                    } else if let Some(path) = stroke.release() {
+                        if crate::gesture::travel(&path) >= 10.0 {
+                            let pts = crate::gesture::normalize(&path);
+                            drop(lock);
+                            return (
+                                200,
+                                format!(
+                                    "{{\"ok\":true,\"points\":\"{}\"}}",
+                                    crate::gesture::to_string(&pts)
+                                ),
+                            );
+                        }
+                    }
+                }
+                InputEventKind::AbsAxis(axis) => {
+                    let code = axis.0;
+                    if code == 0 || code == 53 {
+                        stroke.axis(true, axis_percent(&ranges, code, ev.value()));
+                    } else if code == 1 || code == 54 {
+                        stroke.axis(false, axis_percent(&ranges, code, ev.value()));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    drop(lock);
+    (200, json_err("timeout"))
+}
+
+fn axis_ranges(dev: &evdev::Device) -> std::collections::HashMap<u16, (i32, i32)> {
+    let states = match dev.get_abs_state() {
+        Ok(s) => s,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    [0u16, 1, 53, 54]
+        .iter()
+        .filter_map(|&code| {
+            let i = states.get(code as usize)?;
+            let half = ((i.maximum - i.minimum) / 2).max(1);
+            Some((code, ((i.minimum + i.maximum) / 2, half)))
+        })
+        .collect()
+}
+
+fn axis_percent(ranges: &std::collections::HashMap<u16, (i32, i32)>, code: u16, value: i32) -> i32 {
+    match ranges.get(&code) {
+        Some((centre, half)) => ((value - centre) * 100 / half).clamp(-100, 100),
+        None => 0,
+    }
+}
+
 fn capture(query: &std::collections::HashMap<String, String>) -> (u16, String) {
     let lock = match CAPTURE_LOCK.try_lock() {
         Ok(g) => g,
@@ -446,6 +556,7 @@ fn capture(query: &std::collections::HashMap<String, String>) -> (u16, String) {
                     let kind = match code {
                         16 | 17 => "dpad",
                         9 | 10 => "trigger",
+                        0 | 1 | 3 | 4 => "stick",
                         _ => continue,
                     };
                     drop(lock);


### PR DESCRIPTION
Part of #40. Both inputs are read off the device and turned into a direction that runs an existing mapping. Nothing new is emitted, and no new action scripts.

**Swipes.** A contact landing, moving and lifting becomes a direction. Binds through `[device.<id>.gestures]`, keyed up/down/left/right. The longer axis wins so a sloppy diagonal still reads as one swipe, and travel under `gesture_min_percent` stays a tap.

**Sticks.** Were read and thrown away, so nothing could be offered for them in the Mapper Manager or the KOReader plugin. Bind through `[device.<id>.stick_left]` and `[device.<id>.stick_right]`. An axis fires once when it leaves the deadzone and re-arms at centre, so a held stick does not repeat forever.

Both sections are keyed like the dpad one and reuse its parser and enum. Positions and stick pushes arrive as a percent of the axis range, read once when the device opens, so pads and panels that disagree on range still share one threshold.

Capture no longer skips axes 0, 1, 3 and 4, so a stick push can be recorded.

17 tests pass, including the deadzone and re-arm transitions and the swipe threshold.

Not here: recorded gestures replayed by name, the other half of #40.