### PR TITLE
fix(waf): leave grab out of the config unless it was set

### DIFF
--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -17,6 +17,7 @@ var MapperManager = (function() {
     var ini = null;            // parsed config
     var pendingSlot = null;    // slot object awaiting an action pick
     var captureXhrAbort = null;
+    var grabWasSet = false;   // config had an explicit grab key, or the user touched the toggle
     var actionTab = "auto";     // which tab is showing in the action picker
     var currentDeviceId = null; // currently selected device on Bindings tab
     var editingDeviceId = null; // device being edited in the detail overlay (null = new)
@@ -858,6 +859,7 @@ var MapperManager = (function() {
         getEl("devDetailName").value = prefillName || "";
         getEl("devDetailUniq").value = prefillUniq || "";
         getEl("devDetailGrab").className = "toggle";
+        grabWasSet = false;
         setDeviceLayout("");
         getEl("btnDeviceDelete").style.display = "none";
         updateDeviceIdView();
@@ -869,8 +871,9 @@ var MapperManager = (function() {
         getEl("deviceDetailTitle").innerHTML = "Edit device";
         getEl("devDetailName").value = getValue("device." + id, "name") || "";
         getEl("devDetailUniq").value = getValue("device." + id, "uniq") || "";
-        var grab = (getValue("device." + id, "grab") || "").toLowerCase() === "true";
-        getEl("devDetailGrab").className = "toggle" + (grab ? " on" : "");
+        var stored = getValue("device." + id, "grab");
+        grabWasSet = stored !== null;
+        getEl("devDetailGrab").className = "toggle" + ((stored || "").toLowerCase() === "true" ? " on" : "");
         setDeviceLayout(getValue("device." + id, "keyboard_layout") || "");
         getEl("btnDeviceDelete").style.display = "block";
         getEl("devDetailIdView").innerHTML = escapeHtml(id);
@@ -888,6 +891,7 @@ var MapperManager = (function() {
     function toggleDeviceDetailGrab() {
         var t = getEl("devDetailGrab");
         t.className = t.className.indexOf(" on") >= 0 ? "toggle" : "toggle on";
+        grabWasSet = true;
     }
 
     function autoIdFromName(s) {
@@ -916,7 +920,7 @@ var MapperManager = (function() {
         var layout = getEl("devDetailLayout").getAttribute("data-code") || "";
 
         setValue("device." + newId, "name", name);
-        setValue("device." + newId, "grab", grab);
+        if (grabWasSet) { setValue("device." + newId, "grab", grab); } else { delValue("device." + newId, "grab"); }
         if (uniq) { setValue("device." + newId, "uniq", uniq); } else { delValue("device." + newId, "uniq"); }
         if (layout) { setValue("device." + newId, "keyboard_layout", layout); } else { delValue("device." + newId, "keyboard_layout"); }
         delValue("device." + newId, "path");

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -17,7 +17,6 @@ var MapperManager = (function() {
     var ini = null;            // parsed config
     var pendingSlot = null;    // slot object awaiting an action pick
     var captureXhrAbort = null;
-    var grabWasSet = false;   // config had an explicit grab key, or the user touched the toggle
     var actionTab = "auto";     // which tab is showing in the action picker
     var currentDeviceId = null; // currently selected device on Bindings tab
     var editingDeviceId = null; // device being edited in the detail overlay (null = new)
@@ -274,6 +273,11 @@ var MapperManager = (function() {
             if (entries[i][0] === key) { entries[i][1] = value; return; }
         }
         entries.push([key, value]);
+    }
+
+    function setOrDel(section, key, value) {
+        if (value) setValue(section, key, value);
+        else delValue(section, key);
     }
 
     function delValue(section, key) {
@@ -859,7 +863,6 @@ var MapperManager = (function() {
         getEl("devDetailName").value = prefillName || "";
         getEl("devDetailUniq").value = prefillUniq || "";
         getEl("devDetailGrab").className = "toggle";
-        grabWasSet = false;
         setDeviceLayout("");
         getEl("btnDeviceDelete").style.display = "none";
         updateDeviceIdView();
@@ -871,9 +874,8 @@ var MapperManager = (function() {
         getEl("deviceDetailTitle").innerHTML = "Edit device";
         getEl("devDetailName").value = getValue("device." + id, "name") || "";
         getEl("devDetailUniq").value = getValue("device." + id, "uniq") || "";
-        var stored = getValue("device." + id, "grab");
-        grabWasSet = stored !== null;
-        getEl("devDetailGrab").className = "toggle" + ((stored || "").toLowerCase() === "true" ? " on" : "");
+        var grab = (getValue("device." + id, "grab") || "").toLowerCase() === "true";
+        getEl("devDetailGrab").className = "toggle" + (grab ? " on" : "");
         setDeviceLayout(getValue("device." + id, "keyboard_layout") || "");
         getEl("btnDeviceDelete").style.display = "block";
         getEl("devDetailIdView").innerHTML = escapeHtml(id);
@@ -891,7 +893,6 @@ var MapperManager = (function() {
     function toggleDeviceDetailGrab() {
         var t = getEl("devDetailGrab");
         t.className = t.className.indexOf(" on") >= 0 ? "toggle" : "toggle on";
-        grabWasSet = true;
     }
 
     function autoIdFromName(s) {
@@ -910,7 +911,7 @@ var MapperManager = (function() {
             showMessage("Set a name or MAC", true);
             return;
         }
-        var grab = getEl("devDetailGrab").className.indexOf(" on") >= 0 ? "true" : "false";
+        var exclusive = getEl("devDetailGrab").className.indexOf(" on") >= 0;
 
         if (!editingDeviceId && listDeviceIds().indexOf(newId) >= 0) {
             showMessage("A device with that name already exists", true);
@@ -919,11 +920,14 @@ var MapperManager = (function() {
 
         var layout = getEl("devDetailLayout").getAttribute("data-code") || "";
 
-        setValue("device." + newId, "name", name);
-        if (grabWasSet) { setValue("device." + newId, "grab", grab); } else { delValue("device." + newId, "grab"); }
-        if (uniq) { setValue("device." + newId, "uniq", uniq); } else { delValue("device." + newId, "uniq"); }
-        if (layout) { setValue("device." + newId, "keyboard_layout", layout); } else { delValue("device." + newId, "keyboard_layout"); }
-        delValue("device." + newId, "path");
+        var section = "device." + newId;
+        var pinned = getValue(section, "grab") !== null || exclusive;
+
+        setValue(section, "name", name);
+        setOrDel(section, "grab", pinned ? String(exclusive) : "");
+        setOrDel(section, "uniq", uniq);
+        setOrDel(section, "keyboard_layout", layout);
+        delValue(section, "path");
 
         if (!currentDeviceId) currentDeviceId = newId;
         closeDeviceDetail();


### PR DESCRIPTION
saving a device in the WAF wrote `grab` every time, so opening the edit dialog for any reason and hitting Save pinned the device to an explicit value. that kills automatic mode, where the daemon decides from the node itself, and the dialog gives you no way back to it. adding a new device was worse, since the toggle starts off and the save wrote `grab = false`, which stops the daemon claiming a gamepad it should have claimed.

the key now gets written only when the file already carried it or the toggle is on, so it needs no extra state. the three set-or-delete branches on save fold into one helper while i was in there.

tested on device with the patched js deployed

- `keychron_m6`, no `grab` line, opened and saved untouched, block comes back unchanged
- same device with Exclusive flipped on, `grab = true` lands
- flipped back off, `grab = false` lands, so an explicit false is still reachable
- `bt_keyboard`, already `grab = true` and `passthrough = true`, opened and saved untouched, keeps both

one thing i noticed while testing and did not touch here, the WAF config round trip eats every comment in `config.ini`. it dropped all 28 comment lines including the commented `[device.gamepad]` example block. `button_mapper.py` is append only for exactly that reason, `POST /config` is not. separate fix.