### PR TITLE
Select the MT slot before the contact axes in tap.sh

### DIFF
--- a/scripts/tap.sh
+++ b/scripts/tap.sh
@@ -97,6 +97,8 @@ ev() { le32 0; le32 0; le16 "$1"; le16 "$2"; le32 "$3"; }
 
 DOWN=$(
     ev 1 330 1     # BTN_TOUCH down
+    ev 3 47 0      # ABS_MT_SLOT, protocol B wants the slot before its axes
+    ev 3 55 0      # ABS_MT_TOOL_TYPE, finger
     ev 3 57 0      # ABS_MT_TRACKING_ID
     ev 3 58 18     # ABS_MT_PRESSURE
     ev 3 53 "$X"   # ABS_MT_POSITION_X
@@ -107,6 +109,7 @@ DOWN=$(
 )
 UP=$(
     ev 1 330 0     # BTN_TOUCH up
+    ev 3 47 0      # ABS_MT_SLOT, a real finger in between may have moved it
     ev 3 57 -1     # ABS_MT_TRACKING_ID, contact lifted
     ev 0 0 0
 )


### PR DESCRIPTION
Tap page turns do nothing on the 12th gen Paperwhite, reported in #48. That panel is MT protocol B and wants ABS_MT_SLOT ahead of any other MT axis, and tap.sh went straight to ABS_MT_TRACKING_ID, so the report went nowhere with nothing in the log since the write itself succeeds.

Now it reports slot 0 before the contact axes and again on the release, so a real finger touch during the hold cannot leave the contact stuck down. ABS_MT_TOOL_TYPE goes out as 0 for finger, the patch in the issue used 1, which is MT_TOOL_PEN. Panels that do not declare these codes drop them, same as the pressure and width axes already in there.

On the Basic 5 page turns still work after the change, so the extra events do no harm, but that device never showed the bug so only @1lifedo1thing can confirm the fix.

Fixes #48
