### PR TITLE
feat(build): show the git sha8 in dev builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,16 @@
 fn main() {
-    let sha = std::env::var("BUILD_SHA").unwrap_or_else(|_| "dev".to_string());
+    let sha = std::env::var("BUILD_SHA").unwrap_or_else(|_| git_sha8());
     println!("cargo:rustc-env=BUILD_SHA={}", sha);
     println!("cargo:rerun-if-env-changed=BUILD_SHA");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}
+
+fn git_sha8() -> String {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| format!("dev-{}", String::from_utf8_lossy(&o.stdout).trim()))
+        .unwrap_or_else(|| "dev".to_string())
 }


### PR DESCRIPTION
Dev builds always showed a literal `dev` in the WAF footer since `build.rs` only used `BUILD_SHA` when CI set it, which made it impossible to tell which commit was actually running on the device.

Now `build.rs` falls back to `git rev-parse --short=8 HEAD` when `BUILD_SHA` is unset, so local builds report `dev-<sha8>` and the footer picks it up through the existing `/status` build field. Also added `rerun-if-changed=.git/HEAD` so the sha refreshes after a commit instead of cargo caching a stale one. CI release builds are untouched, they keep using the `BUILD_SHA` env var, and plain `dev` remains the fallback if git isn't around.

Tested with a local `cargo build`, the binary carries `dev-b90f3bf3` and the footer renders it.