### PR TITLE
feat(upstart): boot-loop breaker with last_kmsg postmortem

### DIFF
--- a/assets/kindle-button-mapper.upstart
+++ b/assets/kindle-button-mapper.upstart
@@ -8,6 +8,20 @@ respawn limit 5 60
 
 console none
 
+pre-start script
+    base=/mnt/us/kindle-button-mapper
+    cp /proc/last_kmsg "$base/last_kmsg.txt" 2>/dev/null || true
+    n=$(cat "$base/boot_attempts" 2>/dev/null || echo 0)
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    if [ "$n" -ge 3 ]; then
+        echo "$(date) autostart disabled after $n starts without a stable run" >> "$base/boot.log"
+        stop
+        exit 0
+    fi
+    echo $((n + 1)) > "$base/boot_attempts"
+    echo "$(date) start attempt $((n + 1))" >> "$base/boot.log"
+end script
+
 script
     exec /mnt/us/kindle-button-mapper/kindle-button-mapper /mnt/us/kindle-button-mapper/config.ini >>/var/log/kindle-button-mapper.log 2>&1
 end script

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,8 @@ chmod +x "$INSTALL_DIR/kindle-button-mapper" \
          "$INSTALL_DIR/scripts/"*.sh \
          "$INSTALL_DIR/illusion/"*.sh
 
+rm -f "$INSTALL_DIR/boot_attempts"
+
 /usr/sbin/mntroot rw
 
 cp "$INSTALL_DIR/assets/kindle-button-mapper.upstart" /etc/upstart/kindle-button-mapper.conf

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,11 @@ fn main() {
         }
     };
 
+    thread::spawn(|| {
+        thread::sleep(Duration::from_secs(120));
+        let _ = std::fs::remove_file("/mnt/us/kindle-button-mapper/boot_attempts");
+    });
+
     info!(
         "Kindle Button Mapper {} (build {}) starting...",
         env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
Suggested by @mergen3107 in zampierilucas/kindle-hid-passthrough#99. The mapper autostarts at boot, so a firmware change that makes it loop the device would be just as bricky as the hid-passthrough one was. Same guard that shipped there, pre-start counts starts in boot_attempts on /mnt/us, disables autostart after 3 starts without a stable run, and snapshots /proc/last_kmsg plus a boot.log line so a looping boot leaves evidence. The daemon clears the counter after 2 minutes alive, reinstalling resets it.