### PR TITLE
Send page turns to the window in front over X

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,13 @@ The daemon reads requests off `/var/run/kindle-button-mapper-key.fifo`, which is
 how `scripts/key.sh` works without any external tool, and it picks the device.
 On a model with physical page buttons the framework only turns pages for that
 node, so the daemon writes `KEY_PAGEDOWN`/`KEY_PAGEUP` straight into it and the
-reader sees a normal button press. Everywhere else the native reader takes
-`KEY_DOWN` as next page and `KEY_UP` as previous page on the virtual keyboard.
+reader sees a normal button press. Everywhere else the window manager swallows
+page keys, since it only forwards them on models `devcap-get-feature -a
+button.keypad` says have the buttons, so the daemon sends PageDown/PageUp over
+the X socket straight to the window `winmgr` reports in front, which is the
+reader you are looking at. If that window cannot be found it falls back to
+`KEY_DOWN` as next page and `KEY_UP` as previous page on the virtual keyboard,
+which is what the reader takes on some models.
 
 Some firmware ignores injected keys altogether, so `next_page_tap` and
 `prev_page_tap` go in as a touch on the screen instead, near the right and left

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod mapper;
 mod pause;
 mod reload;
 mod vkeyboard;
+mod xkey;
 mod gesture;
 mod waf_helper;
 

--- a/src/vkeyboard.rs
+++ b/src/vkeyboard.rs
@@ -276,7 +276,7 @@ impl Pager {
                 }
             }
             None => {
-                info!("No page buttons found, page turns go to the virtual keyboard");
+                info!("No page buttons found, page turns go to the window in front");
                 Pager::VirtualKeyboard
             }
         }
@@ -315,16 +315,22 @@ impl Pager {
                     *node = None;
                 }
             }
-            Pager::VirtualKeyboard => match vkbd {
-                Some(vkbd) => {
-                    let kbd_code = if forward { KEY_DOWN } else { KEY_UP };
-                    if let Err(e) = tap(vkbd, kbd_code) {
-                        warn!("Page turn failed: {}", e);
-                    }
+            Pager::VirtualKeyboard => {
+                let page_code = if forward { KEY_PAGEDOWN } else { KEY_PAGEUP };
+                if crate::xkey::send_page(page_code) {
+                    return;
                 }
-                // serve() does not open the FIFO in this case.
-                None => warn!("Page turn failed, no uinput keyboard"),
-            },
+                match vkbd {
+                    Some(vkbd) => {
+                        let kbd_code = if forward { KEY_DOWN } else { KEY_UP };
+                        if let Err(e) = tap(vkbd, kbd_code) {
+                            warn!("Page turn failed: {}", e);
+                        }
+                    }
+                    // serve() does not open the FIFO in this case.
+                    None => warn!("Page turn failed, no uinput keyboard"),
+                }
+            }
         }
     }
 }

--- a/src/xkey.rs
+++ b/src/xkey.rs
@@ -1,0 +1,231 @@
+use log::debug;
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::process::Command;
+use std::time::Duration;
+
+const SOCKET: &str = "/tmp/.X11-unix/X0";
+const TIMEOUT: Duration = Duration::from_millis(500);
+
+const KEYCODE_OFFSET: u8 = 8;
+const ATOM_WM_NAME: u32 = 39;
+const KEY_PRESS: u8 = 2;
+const KEY_RELEASE: u8 = 3;
+const MAX_NAME: u32 = 128;
+
+pub fn send_page(evdev_code: u16) -> bool {
+    let Some(title) = active_window_title() else {
+        debug!("X page turn: winmgr does not say what is in front");
+        return false;
+    };
+    let Some((prefix, id)) = title_parts(&title) else {
+        debug!("X page turn: {:?} is not an app window", title);
+        return false;
+    };
+    match turn(prefix, id, (evdev_code as u8).wrapping_add(KEYCODE_OFFSET)) {
+        Ok(()) => {
+            debug!("X page turn sent to {}", id);
+            true
+        }
+        Err(e) => {
+            debug!("X page turn to {}: {}", id, e);
+            false
+        }
+    }
+}
+
+fn turn(prefix: &str, id: &str, keycode: u8) -> io::Result<()> {
+    let mut x = X::connect()?;
+    let window = x
+        .find(prefix, id)?
+        .ok_or_else(|| io::Error::other(format!("no window named {}ID:{}", prefix, id)))?;
+    x.send_key(window, keycode, KEY_PRESS)?;
+    x.send_key(window, keycode, KEY_RELEASE)?;
+    x.request(&[43, 0, 1, 0])?;
+    x.reply()?;
+    Ok(())
+}
+
+fn active_window_title() -> Option<String> {
+    let out = Command::new("lipc-get-prop")
+        .args(["com.lab126.winmgr", "getActiveAppTitle"])
+        .output()
+        .ok()?;
+    let title = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!title.is_empty()).then_some(title)
+}
+
+fn title_parts(title: &str) -> Option<(&str, &str)> {
+    let (prefix, rest) = title.split_once("ID:")?;
+    let id = rest.split('_').next()?;
+    (!prefix.is_empty() && !id.is_empty()).then_some((prefix, id))
+}
+
+fn is_match(name: &str, prefix: &str, id: &str) -> bool {
+    match name
+        .strip_prefix(prefix)
+        .and_then(|r| r.strip_prefix("ID:"))
+    {
+        Some(rest) => rest.split('_').next() == Some(id),
+        None => false,
+    }
+}
+
+struct X {
+    sock: UnixStream,
+    root: u32,
+}
+
+impl X {
+    fn connect() -> io::Result<Self> {
+        let sock = UnixStream::connect(SOCKET)?;
+        sock.set_read_timeout(Some(TIMEOUT))?;
+        sock.set_write_timeout(Some(TIMEOUT))?;
+        let mut x = X { sock, root: 0 };
+
+        let mut req = [0u8; 12];
+        req[0] = b'l';
+        req[2] = 11;
+        x.sock.write_all(&req)?;
+
+        let mut head = [0u8; 8];
+        x.sock.read_exact(&mut head)?;
+        if head[0] != 1 {
+            return Err(io::Error::other(format!("X refused us: {}", head[0])));
+        }
+        let mut setup = vec![0u8; read_u16(&head, 6)? as usize * 4];
+        x.sock.read_exact(&mut setup)?;
+
+        let vendor = read_u16(&setup, 16)? as usize;
+        let padded = vendor + (4 - vendor % 4) % 4;
+        let formats = *setup.get(21).ok_or_else(short)? as usize;
+        x.root = read_u32(&setup, 32 + padded + formats * 8)?;
+        Ok(x)
+    }
+
+    fn request(&mut self, req: &[u8]) -> io::Result<()> {
+        self.sock.write_all(req)
+    }
+
+    fn reply(&mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        let mut head = vec![0u8; 32];
+        self.sock.read_exact(&mut head)?;
+        if head[0] == 0 {
+            return Err(io::Error::other(format!("X error {}", head[1])));
+        }
+        let mut data = vec![0u8; read_u32(&head, 4)? as usize * 4];
+        self.sock.read_exact(&mut data)?;
+        Ok((head, data))
+    }
+
+    fn query_tree(&mut self, window: u32) -> io::Result<Vec<u32>> {
+        let mut req = [0u8; 8];
+        req[0] = 15;
+        req[2] = 2;
+        req[4..].copy_from_slice(&window.to_le_bytes());
+        self.request(&req)?;
+        let (head, data) = self.reply()?;
+        (0..read_u16(&head, 16)? as usize)
+            .map(|i| read_u32(&data, i * 4))
+            .collect()
+    }
+
+    fn name(&mut self, window: u32) -> io::Result<String> {
+        let mut req = [0u8; 24];
+        req[0] = 20;
+        req[2] = 6;
+        req[4..8].copy_from_slice(&window.to_le_bytes());
+        req[8..12].copy_from_slice(&ATOM_WM_NAME.to_le_bytes());
+        req[20..24].copy_from_slice(&MAX_NAME.to_le_bytes());
+        self.request(&req)?;
+        let (head, data) = self.reply()?;
+        let len = (read_u32(&head, 16)? as usize).min(data.len());
+        Ok(String::from_utf8_lossy(&data[..len]).into_owned())
+    }
+
+    fn find(&mut self, prefix: &str, id: &str) -> io::Result<Option<u32>> {
+        let mut found = None;
+        let mut queue = vec![self.root];
+        while let Some(window) = queue.pop() {
+            for child in self.query_tree(window)? {
+                if is_match(&self.name(child)?, prefix, id) {
+                    found = Some(child);
+                }
+                queue.push(child);
+            }
+        }
+        Ok(found)
+    }
+
+    fn send_key(&mut self, window: u32, keycode: u8, kind: u8) -> io::Result<()> {
+        let mut req = [0u8; 44];
+        req[0] = 25;
+        req[2] = 11;
+        req[4..8].copy_from_slice(&window.to_le_bytes());
+        let ev = &mut req[12..];
+        ev[0] = kind;
+        ev[1] = keycode;
+        ev[8..12].copy_from_slice(&self.root.to_le_bytes());
+        ev[12..16].copy_from_slice(&window.to_le_bytes());
+        ev[30] = 1;
+        self.request(&req)
+    }
+}
+
+fn short() -> io::Error {
+    io::Error::other("short X reply")
+}
+
+fn read_u16(buf: &[u8], at: usize) -> io::Result<u16> {
+    buf.get(at..at + 2)
+        .map(|b| u16::from_le_bytes([b[0], b[1]]))
+        .ok_or_else(short)
+}
+
+fn read_u32(buf: &[u8], at: usize) -> io::Result<u32> {
+    buf.get(at..at + 4)
+        .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .ok_or_else(short)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const READER: &str = "L:A_N:application_ID:com.lab126.booklet.reader_M:false_WT:true_S:-2";
+
+    #[test]
+    fn the_window_in_front_is_matched() {
+        let (prefix, id) = title_parts(READER).unwrap();
+        assert_eq!(prefix, "L:A_N:application_");
+        assert_eq!(id, "com.lab126.booklet.reader");
+        assert!(is_match(READER, prefix, id));
+        assert!(is_match(&format!("{}_DM:N", READER), prefix, id));
+        assert!(!is_match(
+            "L:C_N:footerBar_ID:com.lab126.booklet.reader_M:false",
+            prefix,
+            id
+        ));
+        assert!(!is_match(
+            "L:C_N:appToolBar_owner:com.lab126.booklet.reader_ID:com.lab126.KPPMainApp",
+            prefix,
+            id
+        ));
+        assert!(!is_match(
+            "L:A_N:application_ID:com.lab126.booklet.home_M:false",
+            prefix,
+            id
+        ));
+        assert!(!is_match(
+            "L:A_N:application_ID:com.lab126.booklet.reader2_M:false",
+            prefix,
+            id
+        ));
+    }
+
+    #[test]
+    fn titles_without_an_id_are_not_ours() {
+        assert_eq!(title_parts("mesquite"), None);
+        assert_eq!(title_parts("ID:com.lab126.krpp"), None);
+    }
+}


### PR DESCRIPTION
On a Kindle with no page buttons the daemon injected KEY_DOWN/KEY_UP on its
virtual keyboard and hoped the reader took it. On @xbot's KT6 in #49 it
doesn't, so page turns did nothing.

Root cause is awesome. lab126_whisper_touch.lua only forwards PageUp/PageDown
to the reader when `devcap-get-feature -a button.keypad` says the device has
page buttons, and handleWhisperTouchPress marks the key handled either way, so
an injected page key gets swallowed before any app sees it. My Basic 5 reports
`0` for that capability too, so this was never KT6 specific, the only
difference is that the reader there happens to act on the arrow keys and the
KT6's doesn't.

A SendEvent goes to the window itself and misses the grab. The daemon now asks
winmgr which app is in front, finds that window over the X socket and sends
PageDown/PageUp to it, keeping KEY_DOWN/KEY_UP as the fallback when there is no
window to send to. `src/xkey.rs` speaks the X protocol directly on
/tmp/.X11-unix/X0, no new dependency, and no auth since the framework's X runs
without an XAUTHORITY. Matching both the part of the title before `ID:` and the
id itself is what keeps it off the reader's footer bar and toolbar, which carry
the same id on another layer.

Tested on a Basic 5 with a book open, driving the real path.

```sh
/mnt/us/kindle-button-mapper/scripts/auto.sh next_page   # Loc 478 -> 483
/mnt/us/kindle-button-mapper/scripts/auto.sh prev_page   # Loc 483 -> 478
```

Five presses back to back advanced five pages with none dropped, and
`key.sh KEY_PAGEDOWN` through the old path still does nothing, which is the
grab. Unit tests cover the title parsing and the window matching.

Still needs a KT6 to confirm, so Refs rather than Fixes.

Refs #49