### PR TITLE
fix(install): always remount root read-only on exit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 
 set -e
 
+trap '/usr/sbin/mntroot ro 2>/dev/null' EXIT
+trap 'exit 130' INT TERM HUP
+
 SRC_DIR=$(cd "$(dirname "$0")" && pwd)
 INSTALL_DIR=/mnt/us/kindle-button-mapper
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+trap '/usr/sbin/mntroot ro 2>/dev/null' EXIT
+trap 'exit 130' INT TERM HUP
+
 INSTALL_DIR=/mnt/us/kindle-button-mapper
 APPREG_DB=/var/local/appreg.db
 APP_ID=com.lzampier.mappermanager


### PR DESCRIPTION
Both scripts run under `set -e` and open a `mntroot rw` window to write `/etc/upstart` and `/etc/udev/rules.d`. Any failure between that remount and the matching `mntroot ro` aborts the script before the remount back, leaving `/` mounted read-write. The `cp` of `MapperManager.sh` into `/mnt/us/documents` is inside the same window, so a full or missing user store is enough to trigger it.

That is what turns a crash into a brick. `core_pattern` on these devices is a bare `core`, so a crashing framework process dumps into its cwd, which for the daemons is `/`. Root is a 493MB partition already sitting near full (88% on a healthy Basic 5), so a few mesquite or pillowd cores fill it and the framework stops coming up. USB mass storage only ever exports the user store, so there is nothing to delete from the host to recover.

Unrelated to autostart and to the boot-loop breaker. The breaker stops the mapper daemon respawning at boot, it does not remount root. Here the install just ends early and nothing is looping yet.

Verified with a stubbed `mntroot` that records its calls, injecting a failure right after the window opens. Before, `install.sh` and `uninstall.sh` both exit with the last call being `rw`. After, both exit `ro`.

Refs zampierilucas/kindle-hid-passthrough#226