### PR TITLE
fix(tap): skip Scribe pen digitizers

### DIFF
--- a/scripts/tap.sh
+++ b/scripts/tap.sh
@@ -16,11 +16,14 @@ Y_PCT="${2:-50}"
 FB_MODES="/sys/class/graphics/fb0/modes"
 DEVICES="/proc/bus/input/devices"
 
-# The touchscreen is the direct-input device with absolute axes. A gamepad has
-# axes too, but reports no INPUT_PROP_DIRECT.
+# The touchscreen is a direct-input device with absolute axes. A gamepad has
+# axes too, but reports no INPUT_PROP_DIRECT. Kindle Scribe models expose the
+# Wacom pen digitizer as another direct absolute device before the finger
+# touchscreen, so explicitly skip pen/stylus devices.
 touch_node() {
     awk '
-        /^$/ { prop=""; abs=""; handler="" }
+        /^$/ { name=""; prop=""; abs=""; handler="" }
+        /^N: Name=/ { name=tolower($0) }
         /^B: PROP=/ { prop=$2; sub(/PROP=/, "", prop) }
         /^B: ABS=/  { abs=$2 }
         /^H: Handlers=/ {
@@ -31,7 +34,9 @@ touch_node() {
             }
         }
         {
-            if (handler != "" && abs != "" && prop ~ /[23671abefABEF]$/) {
+            if (handler != "" && abs != "" &&
+                    prop ~ /[23671abefABEF]$/ &&
+                    name !~ /(wacom|stylus|pen)/) {
                 print "/dev/input/" handler
                 exit
             }


### PR DESCRIPTION
## Summary

- skip pen and stylus devices when locating the touchscreen
- allow tap page turns to use the finger touchscreen on Kindle Scribe models

## Root cause

`tap.sh` selected the first direct-input device with absolute axes. On a Kindle Scribe 2, the Wacom pen digitizer appears first as `/dev/input/event3`, while the finger touchscreen is `pt_mt` on `/dev/input/event4`. The script therefore wrote multi-touch events to the pen device; the write succeeded, but the native reader never received a finger tap.

## Validation

- `sh -n scripts/tap.sh`
- simulated `/proc/bus/input/devices` fixture containing both `WacomDigitizer` and `pt_mt`; the script selected `/dev/input/event4`
- tested `next_page_tap` and `prev_page_tap` on a Kindle Scribe 2 running Linux 4.9.77-lab126; both changed the native reader page