### PR TITLE
fix(install): copy the pointer rules into the install dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "kindle-button-mapper"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "configparser",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kindle-button-mapper"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "Maps /dev/input events to script execution for Kindle e-readers"
 license = "GPL-3.0-or-later"

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,8 @@ else
     cp "$BIN" "$INSTALL_DIR/kindle-button-mapper"
 fi
 if [ "$SAME_DIR" != 1 ]; then
-    cp "$SRC_DIR/assets/kindle-button-mapper.upstart" "$INSTALL_DIR/assets/"
+    cp "$SRC_DIR/assets/kindle-button-mapper.upstart" \
+       "$SRC_DIR/assets/99-kindle-button-mapper-pointer.rules" "$INSTALL_DIR/assets/"
     cp "$SRC_DIR/uninstall.sh" "$INSTALL_DIR/"
     [ -f "$INSTALL_DIR/config.ini" ] || cp "$SRC_DIR/config.ini" "$INSTALL_DIR/"
     cp "$SRC_DIR/scripts/"*.sh "$INSTALL_DIR/scripts/"


### PR DESCRIPTION
`install.sh` copies the pointer udev rules out of `$INSTALL_DIR/assets` but never puts them there. The copy block only carries `kindle-button-mapper.upstart` across, so on any install where the source tree isn't already the install dir the `cp` hits a missing file, and since the script runs under `set -e` everything after it is skipped, the WAF app install, the udev reload, the config reload and the service start. The mapper lands on disk and never runs.

Came in with the mouse device type work in 61a47b4, so v1.5.0 is the first release carrying it. The file itself is fine in both the release tarball and the kpkg, it just never reaches the install dir.

Found it running `kpm install kindle-hid-passthrough` on a Basic 5, where the bundled mapper step printed `WARNING: Button Mapper install failed, gamepad mapping will be unavailable` and `kindle-button-mapper` stayed `stop/waiting`.

Verified with the patched `install.sh` from the extracted kpm package on the same device. The rules land in `/mnt/us/kindle-button-mapper/assets` and `/etc/udev/rules.d`, MapperManager registers, and the service comes up `start/running`.
