### PR TITLE
fix(upstart): start on the userstore events instead of wmt

### DIFF
--- a/assets/kindle-button-mapper.upstart
+++ b/assets/kindle-button-mapper.upstart
@@ -1,6 +1,6 @@
 # Kindle Button Mapper - maps hardware buttons to custom actions
 # For use with the pre-built binary from releases
-start on started wmt
+start on mounted_userstore or user_store_available
 stop on stopping filesystems
 
 respawn


### PR DESCRIPTION
Fixes #60.

`start on started wmt` only ever fires on MediaTek Kindles. On a Broadcom-era device like the Oasis 2 there is no `wmt` job at all, so the daemon never autostarts and you have to `initctl start kindle-button-mapper` by hand after every reboot.

The mapper does not need the wireless stack. What it needs is `/mnt/us`, since that is where the binary and `config.ini` live, so the start condition now says that directly.

```
start on mounted_userstore or user_store_available
```

`filesystems_userstore` emits `mounted_userstore` from its pre-start right after mounting the user store, and that job is on every model, MediaTek included. `user_store_available` is the other half, it fires when `/mnt/us` comes back after USB drive mode, same event stock `asr_bt_userstore.conf` listens for. The `or` form is fine on upstart 0.6.6, stock `wmt.conf` itself uses `start on (starting acsbtfd or starting wifim)`.

Starting earlier than before does not hurt anything. The device workers loop waiting for their node to show up, and the daemon mknods `/dev/uinput` and the event nodes on its own instead of waiting on udev.

Thanks @xbot for the trace, the boot sequences in the issue are what made the two events distinguishable.

## Tested

Reporter, Oasis 2 on 5.16.2.1.1, Broadcom.

Basic 5, MediaTek, on my side. Emitting either event by hand takes the job from `stop/waiting` to `start/running`, so upstart parses the condition. On a clean reboot the daemon comes up on its own at `fs50`, `mounted_userstore` lands 17.6s into boot, and the log confirms the early start is fine:

```
kindle-button-mapper start/running, process 1483

[INFO kindle_button_mapper] Kindle Button Mapper 1.5.0 starting...
[INFO kindle_button_mapper::vkeyboard] Virtual keyboard at /dev/input/event2
[INFO kindle_button_mapper::input] Waiting for device to appear...
```

The virtual keyboard comes up despite running well before udev, which is the `mknod` fallback in `vkeyboard` doing its job. The boot breaker counted a single attempt and cleared itself after the 120s stable run.