### PR TITLE
chore: bump version to 1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "kindle-button-mapper"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "configparser",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kindle-button-mapper"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Maps /dev/input events to script execution for Kindle e-readers"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Patch bump so the env_logger change in #62 gets a release. kindle-hid-passthrough bundles whatever the latest mapper release is, so it picks this up on its next build.

Binary is 730K in CI now, down from about 1.2M.