### PR TITLE
fix(waf): clear the mesquite cache on install and uninstall

### DIFF
--- a/illusion/install-waf-app.sh
+++ b/illusion/install-waf-app.sh
@@ -27,10 +27,13 @@ fi
 
 echo "1. App files at $APP_DIR"
 
-echo "2. Setting scriptlet permissions"
+echo "2. Clearing cached app assets"
+rm -rf "/var/local/mesquite/$APP_ID" /var/local/mesquite/MapperManager 2>/dev/null
+
+echo "3. Setting scriptlet permissions"
 chmod +x "$SCRIPTLET" 2>/dev/null
 
-echo "3. Registering app"
+echo "4. Registering app"
 if [ -f "$APPREG_DB" ]; then
     existing=$(sqlite3 "$APPREG_DB" "SELECT handlerId FROM handlerIds WHERE handlerId='$APP_ID';" 2>/dev/null)
     if [ -z "$existing" ]; then
@@ -54,7 +57,7 @@ else
     echo "   WARNING: appreg.db not found at $APPREG_DB"
 fi
 
-echo "4. Installing scriptlet"
+echo "5. Installing scriptlet"
 cp "$SCRIPTLET" "$SCRIPTLET_DEST"
 chmod +x "$SCRIPTLET_DEST"
 echo "   Installed at $SCRIPTLET_DEST"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -36,6 +36,7 @@ fi
 /usr/sbin/mntroot ro || true
 
 rm -rf "$INSTALL_DIR"
+rm -rf "/var/local/mesquite/$APP_ID" /var/local/mesquite/MapperManager
 rm -f /mnt/us/documents/MapperManager.sh
 
 echo "Uninstalled."


### PR DESCRIPTION
mesquite caches the app html and js under /var/local/mesquite per app id and we never cleared ours, so an upgrade could keep serving the old UI and an uninstall left the directory sitting there.

found this doing three full kpm install and uninstall cycles on a wiped device. the cache mtime never changed once across all of them, and it was the only difference between a first time install and a reinstall. kindle-hid-passthrough already does exactly this for BTManager in clearWafCache, so this just brings the mapper side in line.

not verified on device yet, my kindle dropped off tailscale mid session. both scripts pass sh -n.