### PR TITLE
feat(layout): add a key_repeat setting so a held key repeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ grab = true
 # type = mouse             # mapped buttons act instead of clicking
 # keyboard_layout = fr     # XKB layout override (comma list for an Alt+Shift toggle, e.g. us,ru)
 # passthrough = true       # required for keyboard_layout to reach KOReader
+# key_repeat = 250,20      # X key auto-repeat: delay in ms, then repeats per second
 
 [device.gamepad.buttons]
 # button_code = /path/to/script.sh
@@ -127,6 +128,14 @@ are the group toggles from a comma list, since KOReader has nothing to toggle wi
 Set `type = mouse` to map a mouse's buttons. Mapped buttons run their action
 instead of clicking; the pointer, wheel and unmapped buttons keep working as a
 normal mouse.
+
+Set `key_repeat` to `delay_ms,rate_per_second` (e.g. `250,20`) to make a held
+key repeat. The firmware starts X with `-ardelay 0 -arinterval 0`, so nothing
+repeats anywhere in the native reader, a WAF app or kterm until a rate is set;
+the mapper applies yours whenever that device connects. It is a system-wide X
+setting, so on a model with physical page buttons a held button will turn pages
+repeatedly too. Leave it unset to keep the firmware's behaviour. KOReader reads
+the event node itself and never sees this setting.
 
 A button fires as soon as it goes down. Give it a `longpress` mapping and it
 fires on release instead, since a short press is only a short press once you

--- a/config.ini
+++ b/config.ini
@@ -27,6 +27,7 @@ gesture_tolerance = 0.30
 # uniq = AA:BB:CC:DD:EE:FF
 # grab = false
 # keyboard_layout = fr        # optional XKB layout, re-applied on every connect
+# key_repeat = 250,20        # X key auto-repeat: delay ms, repeats per second
                               # reaches KOReader too, with grab + passthrough
 #
 # kindle.sh drives the native Kindle reader, koreader.sh drives KOReader.

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct DeviceConfig {
     /// of the mouse keeps working.
     pub mouse: bool,
     pub keyboard_layout: Option<String>,
+    pub key_repeat: Option<(u32, u32)>,
     pub mappings: HashMap<Key, String>,
     pub long_press_mappings: HashMap<Key, String>,
     pub dpad_mappings: HashMap<DpadDirection, String>,
@@ -105,6 +106,7 @@ impl DeviceConfig {
             passthrough: false,
             mouse: false,
             keyboard_layout: None,
+            key_repeat: None,
             mappings: HashMap::new(),
             long_press_mappings: HashMap::new(),
             dpad_mappings: HashMap::new(),
@@ -264,6 +266,7 @@ impl Config {
                         .map(str::trim)
                         .filter(|v| !v.is_empty())
                         .map(String::from);
+                    dev.key_repeat = get(entries, "key_repeat").and_then(parse_key_repeat);
                 }
                 Some("buttons") => fill_key_map(entries, &mut dev.mappings),
                 Some("longpress") => fill_key_map(entries, &mut dev.long_press_mappings),
@@ -304,6 +307,13 @@ fn get<'a>(section: &'a HashMap<String, Option<String>>, key: &str) -> Option<&'
 
 fn parse_bool(v: &str) -> bool {
     matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "yes" | "1" | "on")
+}
+
+fn parse_key_repeat(v: &str) -> Option<(u32, u32)> {
+    let (delay, rate) = v.split_once(',')?;
+    let delay: u32 = delay.trim().parse().ok()?;
+    let rate: u32 = rate.trim().parse().ok()?;
+    (delay > 0 && rate > 0).then_some((delay, rate))
 }
 
 fn fill_key_map(
@@ -420,6 +430,22 @@ mod tests {
         assert!(pad.grab && !pad.grab_explicit);
         let kbd = cfg.devices.iter().find(|d| d.id == "kbd").expect("kbd");
         assert!(kbd.grab && kbd.grab_explicit);
+    }
+
+    #[test]
+    fn key_repeat_takes_a_delay_and_a_rate() {
+        assert_eq!(parse_key_repeat("250,20"), Some((250, 20)));
+        assert_eq!(parse_key_repeat(" 400 , 25 "), Some((400, 25)));
+        assert_eq!(parse_key_repeat("250"), None);
+        assert_eq!(parse_key_repeat("0,20"), None);
+        assert_eq!(parse_key_repeat("250,0"), None);
+        assert_eq!(parse_key_repeat("fast,20"), None);
+
+        let cfg = load_str(
+            "kbm-key-repeat.ini",
+            "[device.kbd]\nuniq = 11:22:33:44:55:66\nkey_repeat = 250,20\n",
+        );
+        assert_eq!(cfg.devices[0].key_repeat, Some((250, 20)));
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -40,6 +40,16 @@ impl Drop for LayoutOverride {
     }
 }
 
+pub fn set_key_repeat(delay_ms: u32, rate: u32) {
+    let delay = delay_ms.to_string();
+    let rate = rate.to_string();
+    if run("xset", &["-display", ":0", "r", "rate", &delay, &rate]) {
+        info!("key repeat {delay_ms}ms then {rate}/s");
+    } else {
+        warn!("key repeat {delay_ms},{rate}: xset failed");
+    }
+}
+
 fn symbols(groups: &[&str]) -> String {
     let mut s = String::from("default partial alphanumeric_keys modifier_keys\nxkb_symbols \"basic\" {\n");
     for (i, g) in groups.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
                     if gamepad {
                         cfg.apply_default_layout();
                         mapper = Mapper::new(&cfg, &settings);
-                    } else if cfg.keyboard_layout.is_none() {
+                    } else if cfg.keyboard_layout.is_none() && cfg.key_repeat.is_none() {
                         info!(
                             "[{}] no mappings and not a gamepad — leaving it alone until something is mapped",
                             cfg.id
@@ -277,6 +277,9 @@ fn device_worker(mut cfg: config::DeviceConfig, mut settings: WorkerSettings) {
                         (true, false, false) => "exclusive",
                     }
                 );
+                if let Some((delay, rate)) = cfg.key_repeat {
+                    layout::set_key_repeat(delay, rate);
+                }
                 if let Some(ref script) = settings.on_connect {
                     info!("[{}] running on_connect script", cfg.id);
                     execute_script(script);


### PR DESCRIPTION
Fixes #64.

Holding a key never repeats anywhere in the native reader on a Kindle, and it is not the mapper. The firmware starts the X server with auto-repeat zeroed out

```
Xorg -nolisten tcp +bs -ardelay 0 -arinterval 0
```

Measured on a Basic 5 at a clean boot, global auto-repeat and the per-key flags are already on. Only the rate is zero, `repeatDelay = 0 ms`, `repeatInterval = 0 ms`, and that alone stops repeat. A two second hold of a key in the native search bar types one character. Set a rate with nothing else changed and the same hold types about 35.

A device block can now set

```ini
[device.bt_keyboard]
name = BT Keyboard
key_repeat = 250,20
```

and the daemon runs `xset r rate 250 20` when that device connects, which is late enough for X to be up (the daemon itself starts before Xorg). The rate survives the framework's keymap re-pin, so once per connect is enough, and it goes back to the firmware default on reboot. Opt-in, since on a model with physical page buttons a held button would then turn pages repeatedly.

Verified on device against a synthetic keyboard the daemon grabs: fresh boot reads 0/0, connect a device with `key_repeat = 250,20`, log says `key repeat 250ms then 20/s`, X reads back 250/50, and a 3 second hold of a letter types a stream instead of one character.

Note this reaches X clients (native reader, WAF apps, kterm). KOReader reads the event node itself and has its own repeat handling.