### PR TITLE
feat(kpm): package kindle-button-mapper as a .kpkg

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -102,6 +102,17 @@ jobs:
           fi
           echo "All required files present."
 
+      - name: Create KPM package
+        run: |
+          sh kpm/gen-manifests.sh
+          # Stale index means KPM never offers the upgrade.
+          git diff --exit-code kpm/repo.json
+          cp kpm/manifest.json output/
+          # KPM only finds manifest.json at the archive root, so no ./ prefix.
+          tar -czf "kindle-button-mapper.kpkg" -C output $(ls -A output)
+          tar -tzf kindle-button-mapper.kpkg | grep -qx manifest.json
+          ls -lh kindle-button-mapper.kpkg
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -112,7 +123,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: kindle-button-mapper-armv7.tar.gz
+          files: |
+            kindle-button-mapper-armv7.tar.gz
+            kindle-button-mapper.kpkg
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+kpm/manifest.json

--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ Everything else goes over `lipc`.
 
 `keep_awake = true` (default) resets the screensaver timer on input so the device stays awake while a controller is connected, without blocking the power button.
 
+## Install with KPM
+
+If you have [KPM](https://kindlemodding.org/kindle-dev/kpm/) installed, add this repository once and install:
+
+```bash
+kpm add-repo https://raw.githubusercontent.com/zampierilucas/kindle-button-mapper-rs/master/kpm/repo.json
+kpm install kindle-button-mapper
+```
+
+`kpm upgrade` picks up later releases and keeps your `config.ini`. `kpm uninstall kindle-button-mapper` removes the binary, the upstart job, the udev rule and the MapperManager app.
+
 ## Install from release
 
 Grab the latest `kindle-button-mapper-armv7.tar.gz` from the [releases page](https://github.com/zampierilucas/kindle-button-mapper-rs/releases), copy it to the Kindle, extract, and run the installer:

--- a/justfile
+++ b/justfile
@@ -41,6 +41,10 @@ test:
 clean:
     cargo clean
 
+# Restamp kpm/repo.json from Cargo.toml and derive kpm/manifest.json
+kpm-manifests:
+    sh kpm/gen-manifests.sh
+
 # Deploy to Kindle
 deploy: build-kindle
     @echo "Deploying to Kindle..."

--- a/kpm/gen-manifests.sh
+++ b/kpm/gen-manifests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+cd "$(dirname "$0")/.."
+
+VERSION=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+[ -n "$VERSION" ] || { echo "no version in Cargo.toml" >&2; exit 1; }
+
+jq --argjson v "[$(echo "$VERSION" | tr . ,)]" \
+   '.packages[].artifacts[0].version = $v' kpm/repo.json > kpm/repo.json.tmp
+mv kpm/repo.json.tmp kpm/repo.json
+
+jq '.packages | to_entries[0] as $e | {
+      manifest_version: 2,
+      id: $e.key,
+      name: $e.value.name,
+      author: $e.value.author,
+      description: $e.value.description,
+      version: $e.value.artifacts[0].version,
+      dependencies: $e.value.artifacts[0].dependencies,
+      supported_platforms: $e.value.artifacts[0].supported_platforms
+    }' kpm/repo.json > kpm/manifest.json

--- a/kpm/repo.json
+++ b/kpm/repo.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 1,
+  "id": "kindle-button-mapper",
+  "name": "Kindle Button Mapper",
+  "description": "Releases of Kindle Button Mapper, an input remapper for Kindle e-readers.",
+  "packages": {
+    "kindle-button-mapper": {
+      "name": "Kindle Button Mapper",
+      "author": "Lucas Zampieri",
+      "description": "Maps input events from keyboards, gamepads and remotes to page turns, taps, key injection and shell scripts, with a touchscreen manager app to edit the bindings on device.",
+      "artifacts": [
+        {
+          "url": "https://github.com/zampierilucas/kindle-button-mapper-rs/releases/latest/download/kindle-button-mapper.kpkg",
+          "version": [
+            1,
+            5,
+            2
+          ],
+          "dependencies": [],
+          "supported_platforms": [
+            "kindlehf",
+            "kindlepw2"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "$1" = upgrade ]; then
+    exit 0
+fi
+
 trap '/usr/sbin/mntroot ro 2>/dev/null' EXIT
 trap 'exit 130' INT TERM HUP
 


### PR DESCRIPTION
packages kbm for KPM the same way hid does, with a repo index stamped from Cargo.toml, a derived manifest.json, and a CI step that ships the .kpkg alongside the tarball. uninstall.sh now exits early when KPM calls it with `upgrade`, so config.ini survives.

no wrapper scripts needed here, the root install.sh and uninstall.sh already sit at the archive root and install.sh's extracted-tarball detection matches the .kpkg layout as is.

tested on a 5.16.2.1.1 kindle running KPM v0.2.3, serving both packages from a local repo over the network. installing over an existing manual install keeps config.ini and swaps the binary while the daemon is running, upgrading 1.5.2 to 1.5.3 keeps config.ini byte for byte, uninstall clears the install dir, upstart job, udev rule, library scriptlet and appreg rows, and a fresh install from clean brings it all back.

that device reports itself as kindlepw2, so kindlehf is listed but untested. a real button press is untested too since nothing was paired at the time.
