### PR TITLE
chore: bump version to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "kindle-button-mapper"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "configparser",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kindle-button-mapper"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2021"
 description = "Maps /dev/input events to script execution for Kindle e-readers"
 license = "GPL-3.0-or-later"

--- a/kpm/repo.json
+++ b/kpm/repo.json
@@ -14,7 +14,7 @@
           "version": [
             1,
             5,
-            2
+            3
           ],
           "dependencies": [],
           "supported_platforms": [


### PR DESCRIPTION
first release carrying the .kpkg, so the KPM index has an artifact to point at.