### PR TITLE
feat(koreader): deliver events to the plugin's loopback port first

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,15 @@ That covers everything drawn by X, which is the native reader, kterm and anythin
 launched under it. KOReader is not an X client: it opens the keyboard's event node
 itself and maps it through a hardcoded US table, so the bind-mount cannot reach it.
 The mapper closes that gap separately, by sending the character KOReader should have
-typed over its HTTP Inspector. The layout comes from the same place X gets it, by
+typed over its KOReader event endpoint (the HID Passthrough plugin's loopback port,
+or the HTTP Inspector as fallback). The layout comes from the same place X gets it, by
 asking `xkbcomp` to resolve the running keymap, so a language needs no data of its
 own. Two things have to be set.
 
 - `grab = true` and `passthrough = true` on the device, so the mapper holds the
   keyboard and KOReader reads only what the mapper relays.
-- KOReader's **HTTP Inspector** plugin enabled, the same one the `koreader:` actions
-  already use.
+- A KOReader that can take events, the HID Passthrough KOReader plugin (or the
+  HTTP Inspector enabled), the same channel the `koreader:` actions already use.
 
 Letters, digits, space and the editing keys relay as keycodes exactly as before,
 since KOReader types those correctly on its own and its shortcuts depend on them.
@@ -160,12 +161,12 @@ Three helper scripts ship with the mapper, so a binding can drive either reader:
 
 | | `scripts/auto.sh` (whatever is on screen) | `scripts/kindle.sh` (native reader) | `scripts/koreader.sh` (KOReader) |
 |---|---|---|---|
-| How it talks to the reader | picks one of the two below | virtual keyboard + `lipc` | HTTP Inspector on `localhost:8080` |
-| Setup needed | none | none | HTTP Inspector auto-start |
+| How it talks to the reader | picks one of the two below | virtual keyboard + `lipc` | KOReader event endpoint on `localhost:8323` (or the HTTP Inspector on `8080`) |
+| Setup needed | none | none | HID Passthrough KOReader plugin (or HTTP Inspector auto-start) |
 | Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `next_page_tap`, `prev_page_tap`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
 
 `auto.sh` is what the Auto tab in MapperManager writes, and it is the one to use
-if you read in both: it sends the event to KOReader's HTTP Inspector and falls
+if you read in both: it sends the event to KOReader and falls
 back to the native reader when nothing is listening there. One binding per
 button covers both readers.
 
@@ -202,7 +203,7 @@ The panel never turns with the screen, so a tap for the right edge of a
 landscape page has to be rotated back into panel coordinates. `tap.sh` asks the
 framework which way up it is and does that itself. KOReader rotates in software
 and tells nobody, so there it reads as upright and the tap lands where it did in
-portrait — use its HTTP Inspector, which turns the page whatever the rotation.
+portrait — send it a KOReader event instead, which turns the page whatever the rotation.
 Set `TAP_ROTATION` to `0`, `90`, `180` or `270` to force the angle.
 
 Everything else goes over `lipc`.
@@ -251,7 +252,7 @@ Uninstall: `ssh kindle "sh /mnt/us/kindle-button-mapper/uninstall.sh"` (the scri
 - Linux kernel with evdev (`/dev/input/eventX`) — present on all stock Kindles.
 - An input device the Kindle can see — e.g. a Bluetooth gamepad/remote bridged via [kindle-hid-passthrough](https://github.com/zampierilucas/kindle-hid-passthrough), or any USB OTG HID device.
 - Nothing extra for the native Kindle reader — `scripts/kindle.sh` and `scripts/auto.sh` only need the daemon running.
-- **KOReader HTTP Inspector** (for KOReader integration): enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. The default mappings in `scripts/koreader.sh` send commands to `localhost:8080`. MapperManager warns you in the KOReader action tab when this auto-start is off.
+- **KOReader integration**: nothing extra with the [HID Passthrough](https://github.com/zampierilucas/kindle-hid-passthrough) KOReader plugin installed, it serves the event endpoint on `localhost:8323`. Without it, enable auto-start once in KOReader → *Tools → More Tools → HTTP Inspector → Auto-start HTTP server*. MapperManager warns you in the KOReader action tab when neither is set up.
 
 ## Hardware
 

--- a/illusion/MapperManager/script.js
+++ b/illusion/MapperManager/script.js
@@ -768,7 +768,7 @@ var MapperManager = (function() {
     function showAutoNote() {
         var el = getEl("koreaderStatus");
         el.className = "koreader-status";
-        el.innerHTML = "Goes to KOReader when it is running with the HTTP Inspector on, "
+        el.innerHTML = "Goes to KOReader when it is running, "
             + "and to the native reader otherwise \u2014 one binding covers both.";
     }
 
@@ -776,11 +776,11 @@ var MapperManager = (function() {
         var el = getEl("koreaderStatus");
         el.className = "koreader-status hidden";
         getJSON("/koreader/status", function(data, err) {
-            if (actionTab !== "koreader" || !data || err || data.autostart) return;
+            if (actionTab !== "koreader" || !data || err || data.autostart || data.plugin) return;
             el.className = "koreader-status";
-            el.innerHTML = "KOReader HTTP Inspector is off. In KOReader, open "
-                + "<b>Tools → More Tools → HTTP Inspector → Auto start HTTP server</b> "
-                + "to use these actions.";
+            el.innerHTML = "KOReader can't take these actions yet. Install the "
+                + "HID Passthrough KOReader plugin, or in KOReader open "
+                + "<b>Tools → More Tools → HTTP Inspector → Auto start HTTP server</b>.";
         });
     }
 

--- a/scripts/koreader.sh
+++ b/scripts/koreader.sh
@@ -12,17 +12,19 @@
 #   font_down [n]    - Decrease font size (default: 1)
 #   event <name> [args] - Send arbitrary event
 
-KOREADER_URL="http://localhost:8080/koreader/event"
+KOREADER_PORTS="8323 8080"
 LOG_PATH="/var/log/kindle-button-mapper.log"
 
 # Send event to KOReader. Exits non-zero when it did not land, which is what
 # lets auto.sh fall back to the native reader. KBM_QUIET=1 silences the warning
 # for callers that have a fallback.
 send_event() {
-    if curl -s --connect-timeout 1 "${KOREADER_URL}/$1" >/dev/null 2>&1; then
-        return 0
-    fi
-    [ -z "$KBM_QUIET" ] && echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  koreader.sh: KOReader not reachable at ${KOREADER_URL} (event '$1' dropped); KOReader may be closed, or HTTP Inspector auto-start is off." >> "$LOG_PATH" 2>/dev/null
+    for port in $KOREADER_PORTS; do
+        if curl -s --connect-timeout 1 "http://localhost:${port}/koreader/event/$1" >/dev/null 2>&1; then
+            return 0
+        fi
+    done
+    [ -z "$KBM_QUIET" ] && echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  koreader.sh: KOReader not reachable on ports ${KOREADER_PORTS} (event '$1' dropped); KOReader may be closed, or its HID Passthrough plugin is missing." >> "$LOG_PATH" 2>/dev/null
     return 1
 }
 

--- a/src/koreader.rs
+++ b/src/koreader.rs
@@ -3,30 +3,30 @@ use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
 use std::time::Duration;
 
-const PORT: u16 = 8080;
+const PORTS: [u16; 2] = [8323, 8080];
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
 const WRITE_TIMEOUT: Duration = Duration::from_millis(300);
 const READ_TIMEOUT: Duration = Duration::from_millis(300);
 
-fn connect() -> Option<TcpStream> {
-    let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, PORT));
-    match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
-        Ok(s) => {
-            let _ = s.set_nodelay(true);
-            let _ = s.set_write_timeout(Some(WRITE_TIMEOUT));
-            Some(s)
-        }
-        Err(e) => {
-            debug!("KOReader not reachable on port {}: {}", PORT, e);
-            None
+fn connect() -> Option<(TcpStream, u16)> {
+    for port in PORTS {
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+        match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+            Ok(s) => {
+                let _ = s.set_nodelay(true);
+                let _ = s.set_write_timeout(Some(WRITE_TIMEOUT));
+                return Some((s, port));
+            }
+            Err(e) => debug!("KOReader not reachable on port {}: {}", port, e),
         }
     }
+    None
 }
 
-fn get(stream: &mut TcpStream, path: &str) -> bool {
+fn get(stream: &mut TcpStream, port: u16, path: &str) -> bool {
     let req = format!(
         "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
-        path, PORT
+        path, port
     );
     stream.write_all(req.as_bytes()).is_ok()
 }
@@ -42,13 +42,13 @@ pub fn reachable() -> bool {
 /// The inspector closes the connection after every response, so there is
 /// nothing to keep alive between calls.
 pub fn send_event(event: &str) -> bool {
-    let mut stream = match connect() {
+    let (mut stream, port) = match connect() {
         Some(s) => s,
         None => return false,
     };
     let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
 
-    if !get(&mut stream, &format!("/koreader/event/{}", event)) {
+    if !get(&mut stream, port, &format!("/koreader/event/{}", event)) {
         debug!("KOReader event '{}' not sent", event);
         return false;
     }
@@ -73,11 +73,11 @@ pub fn send_event(event: &str) -> bool {
 /// answers on the 50ms UI tick, and at typing speed that would stall the
 /// event loop for a tick per character.
 pub fn send_text(text: &str) -> bool {
-    let mut stream = match connect() {
+    let (mut stream, port) = match connect() {
         Some(s) => s,
         None => return false,
     };
-    get(&mut stream, &text_path(text))
+    get(&mut stream, port, &text_path(text))
 }
 
 /// The inspector runs unquoted args through `tonumber`, so a digit would

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -353,11 +353,18 @@ fn status_json(config_path: &str) -> String {
 
 const KOREADER_SETTINGS_PATH: &str = "/mnt/us/koreader/settings.reader.lua";
 
+const KOPLUGIN_EVENTSERVER_PATH: &str =
+    "/mnt/us/koreader/plugins/hidpassthrough.koplugin/eventserver.lua";
+
 fn koreader_status_json() -> String {
     let autostart = fs::read_to_string(KOREADER_SETTINGS_PATH)
         .map(|s| httpinspector_autostart_enabled(&s))
         .unwrap_or(false);
-    format!("{{\"ok\":true,\"autostart\":{}}}", autostart)
+    let plugin = std::path::Path::new(KOPLUGIN_EVENTSERVER_PATH).exists();
+    format!(
+        "{{\"ok\":true,\"autostart\":{},\"plugin\":{}}}",
+        autostart, plugin
+    )
 }
 
 fn httpinspector_autostart_enabled(lua: &str) -> bool {


### PR DESCRIPTION
KOReader actions needed the HTTP Inspector enabled with auto-start on. The HID Passthrough KOReader plugin now serves the same /koreader/event shape on 127.0.0.1:8323 (zampierilucas/kindle-hid-passthrough#257), so every sender here (the in-process fast path, koreader.sh and kolayout's text) tries 8323 first and falls back to 8080 for installs still on the inspector.

The WAF status now also reports whether the plugin endpoint is installed, and the MapperManager banner only asks for inspector auto-start when neither path exists. Docs updated to match.

Tested against the new plugin on the Basic, events land on 8323 with the inspector off.