### PR TITLE
Add suspend as a built-in action, stop long-press bindings repeating

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Three helper scripts ship with the mapper, so a binding can drive either reader:
 |---|---|---|---|
 | How it talks to the reader | picks one of the two below | virtual keyboard + `lipc` | KOReader event endpoint on `localhost:8323` (or the HTTP Inspector on `8080`) |
 | Setup needed | none | none | HID Passthrough KOReader plugin (or HTTP Inspector auto-start) |
-| Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `next_page_tap`, `prev_page_tap`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
+| Actions | `next_page`, `prev_page`, `menu`, `brightness <n>`, `brightness_toggle` | `next_page`, `prev_page`, `next_page_tap`, `prev_page_tap`, `home`, `back`, `toolbar`, `brightness <n>`, `brightness_toggle`, `suspend` | `next_page`, `prev_page`, `menu`, `night_mode`, `rotate`, `font_up`/`font_down`, `toggle_status_bar`, `brightness <n>`, `brightness_toggle` |
 
 `auto.sh` is what the Auto tab in MapperManager writes, and it is the one to use
 if you read in both: it sends the event to KOReader and falls

--- a/scripts/kindle.sh
+++ b/scripts/kindle.sh
@@ -12,6 +12,7 @@
 #   toolbar           - Toggle the reader toolbar
 #   brightness <n>    - Adjust frontlight (positive=up, negative=down)
 #   brightness_toggle - Toggle frontlight off/on
+#   suspend           - Put the device to sleep
 #
 # Page turns are handed to the daemon, which injects into the physical page
 # buttons on models that have them and falls back to KEY_DOWN/KEY_UP on its
@@ -23,6 +24,7 @@
 DIR=$(dirname "$0")
 LOG_PATH="/var/log/kindle-button-mapper.log"
 FL_SAVED="/var/run/kindle-button-mapper-fl"
+SUSPEND_STAMP="/var/run/kindle-button-mapper-suspend"
 
 warn() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') WARN  kindle.sh: $1" >> "$LOG_PATH" 2>/dev/null
@@ -99,11 +101,23 @@ case "$1" in
             fl_set "$prev"
         fi
         ;;
+    suspend)
+        # powerButton is a toggle and a held button repeats its action, so
+        # calls within 2s of the last are dropped: one press, one transition.
+        now=$(date +%s)
+        last=$(cat "$SUSPEND_STAMP" 2>/dev/null)
+        case "$last" in ''|*[!0-9]*) last=0 ;; esac
+        if [ $(( now - last )) -ge 2 ]; then
+            echo "$now" > "$SUSPEND_STAMP" 2>/dev/null
+            lipc-set-prop com.lab126.powerd powerButton 1 2>/dev/null \
+                || warn "suspend: powerd not reachable"
+        fi
+        ;;
     *)
         echo "Usage: $0 <command> [args...]"
         echo "Commands: next_page, prev_page, next_page_tap, prev_page_tap,"
         echo "          home, back, toolbar,"
-        echo "          brightness <n>, brightness_toggle"
+        echo "          brightness <n>, brightness_toggle, suspend"
         exit 1
         ;;
 esac

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -183,6 +183,12 @@ impl Mapper {
                     }
                 }
 
+                // A long-press binding fires once per hold. Falling through
+                // would repeat the short action underneath it.
+                if self.long_press_mappings.contains_key(&key) {
+                    return;
+                }
+
                 // Repeat mode: repeat the normal action at repeat_ms interval
                 if self.repeat_ms > 0 {
                     let should_repeat = self
@@ -320,20 +326,18 @@ impl Mapper {
 
             // Check for long press threshold
             if elapsed >= Duration::from_millis(self.long_press_ms) {
-                // Use long press mapping if available, otherwise fall back to normal
-                let script = self.dpad_longpress_mappings.get(&dir)
-                    .or_else(|| self.dpad_mappings.get(&dir));
-
-                if let Some(script) = script {
-                    // Log first long press differently
+                // A long-press binding fires once per hold; only a plain
+                // mapping keeps repeating while held.
+                if let Some(script) = self.dpad_longpress_mappings.get(&dir) {
                     if !long_press_fired {
                         if self.log_buttons {
                             info!("D-pad long press: {:?} -> {}", dir, script);
                         }
                         self.dpad_longpress_fired.insert(dir, true);
-                    } else {
-                        debug!("D-pad repeat: {:?} -> {}", dir, script);
+                        execute_script(script);
                     }
+                } else if let Some(script) = self.dpad_mappings.get(&dir) {
+                    debug!("D-pad repeat: {:?} -> {}", dir, script);
                     execute_script(script);
                 }
             }
@@ -482,20 +486,18 @@ impl Mapper {
 
             // Check for long press threshold
             if elapsed >= Duration::from_millis(self.long_press_ms) {
-                // Use long press mapping if available, otherwise fall back to normal
-                let script = self.trigger_longpress_mappings.get(&trigger)
-                    .or_else(|| self.trigger_mappings.get(&trigger));
-
-                if let Some(script) = script {
-                    // Log first long press differently
+                // A long-press binding fires once per hold; only a plain
+                // mapping keeps repeating while held.
+                if let Some(script) = self.trigger_longpress_mappings.get(&trigger) {
                     if !long_press_fired {
                         if self.log_buttons {
                             info!("Trigger long press: {:?} -> {}", trigger, script);
                         }
                         self.trigger_longpress_fired.insert(trigger, true);
-                    } else {
-                        debug!("Trigger repeat: {:?} -> {}", trigger, script);
+                        execute_script(script);
                     }
+                } else if let Some(script) = self.trigger_mappings.get(&trigger) {
+                    debug!("Trigger repeat: {:?} -> {}", trigger, script);
                     execute_script(script);
                 }
             }
@@ -562,6 +564,26 @@ mod tests {
         m.handle_stick(1, -70);
         assert_eq!(m.stick_pushed.get(&1).copied(), Some(true));
         assert_eq!(m.stick_pushed.get(&0).copied(), Some(false));
+    }
+
+    #[test]
+    fn a_fired_long_press_does_not_repeat_the_short_action() {
+        let mut cfg = DeviceConfig::for_test("dev");
+        cfg.mappings.insert(Key::new(30), "/bin/true".into());
+        cfg.long_press_mappings.insert(Key::new(30), "/bin/true".into());
+        let mut s = test_settings();
+        s.long_press_ms = 0;
+        s.repeat_ms = 1;
+        let mut m = Mapper::new(&cfg, &s);
+
+        m.handle_press(Key::new(30));
+        m.handle_held(Key::new(30)); // long press fires here, once
+        assert_eq!(m.long_press_fired.get(&Key::new(30)).copied(), Some(true));
+        let fired_at = m.last_repeat.get(&Key::new(30)).copied();
+
+        std::thread::sleep(Duration::from_millis(5));
+        m.handle_held(Key::new(30)); // still held: nothing more may fire
+        assert_eq!(m.last_repeat.get(&Key::new(30)).copied(), fired_at);
     }
 
     #[test]

--- a/src/waf_helper.rs
+++ b/src/waf_helper.rs
@@ -41,6 +41,7 @@ const ACTIONS: &[(&str, &str, &str)] = &[
     ("kindle", "brightness 5", "Brightness +5"),
     ("kindle", "brightness -5", "Brightness -5"),
     ("kindle", "brightness_toggle", "Toggle frontlight"),
+    ("kindle", "suspend", "Sleep / screen off"),
     ("koreader", "next_page", "Next page"),
     ("koreader", "prev_page", "Previous page"),
     ("koreader", "brightness 1", "Brightness +1"),


### PR DESCRIPTION
Adds suspend to the built-in action list, requested in zampierilucas/kindle-hid-passthrough#264. It lands in kindle.sh as a powerButton toggle behind a 2s stamp file, so even a binding that repeats produces one transition per press.

Digging into the repeat complaint from that issue turned up a real bug in the held paths. After a long press fired, the key path kept repeating the short action underneath it, and the d-pad and trigger paths re-fired the long-press script on every continuation event with no throttle at all. Long-press bindings now fire once per hold, plain mappings keep repeating so held page turns still work. Regression test added.

Not yet tested on the device, it is offline right now. I will run it on hardware before merging.